### PR TITLE
fix: 修复自动化 PR 质量门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ permissions:
 
 jobs:
   quality:
-    name: ${{ github.event_name == 'pull_request' && (github.head_ref == 'automation/sync-openai-docs' || github.head_ref == 'automation/translate-openai-docs') && 'Automation PR dispatch guard' || 'Quality gate' }}
-    if: ${{ github.event_name != 'pull_request' || (github.head_ref != 'automation/sync-openai-docs' && github.head_ref != 'automation/translate-openai-docs') }}
+    name: Quality gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -7,7 +7,6 @@ on:
     - cron: "0 16 * * *"
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -103,7 +102,6 @@ jobs:
       - name: Create or update the synchronization pull request
         uses: actions/github-script@v9
         env:
-          BRANCH_UPDATED: ${{ steps.publish.outputs.updated }}
           SYNC_PR_BODY_PATH: ${{ runner.temp }}/sync-pr-body.md
         with:
           script: |
@@ -138,7 +136,6 @@ jobs:
 
             const title = "docs: 同步 OpenAI 官方英文文档";
             const body = await readFile(process.env.SYNC_PR_BODY_PATH, "utf8");
-            let created = false;
             if (!pull) {
               const response = await github.rest.pulls.create({
                 owner,
@@ -149,7 +146,6 @@ jobs:
                 body,
               });
               pull = response.data;
-              created = true;
             } else {
               const response = await github.rest.pulls.update({
                 owner,
@@ -162,12 +158,3 @@ jobs:
             }
 
             core.notice(`Synchronization PR: ${pull.html_url}`);
-            if (created || process.env.BRANCH_UPDATED === "true") {
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: "ci.yml",
-                ref: process.env.SYNC_BRANCH,
-              });
-              core.notice(`Dispatched Quality gate for ${process.env.SYNC_BRANCH}.`);
-            }

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -12,7 +12,6 @@ on:
     - cron: "0 17 * * *"
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -127,7 +126,7 @@ jobs:
         if: steps.publish.outputs.has_changes == 'true'
         run: git diff --name-only "origin/$BASE_BRANCH...HEAD" -- docs/zh > "$RUNNER_TEMP/translation-paths.txt"
 
-      - name: Create the translation pull request and dispatch its gate
+      - name: Create the translation pull request
         if: steps.publish.outputs.has_changes == 'true'
         uses: actions/github-script@v9
         env:
@@ -187,10 +186,3 @@ jobs:
               pull = response.data;
             }
             core.notice(`Translation PR: ${pull.html_url}`);
-            await github.rest.actions.createWorkflowDispatch({
-              owner,
-              repo,
-              workflow_id: "ci.yml",
-              ref: process.env.TRANSLATION_BRANCH,
-            });
-            core.notice(`Dispatched Quality gate for ${process.env.TRANSLATION_BRANCH}.`);

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -99,14 +99,14 @@ pnpm test
 - 每次都从受信任的 `main` 重建该分支；专用分支更新使用 `--force-with-lease`，不会运行分支自身修改过的脚本。
 - 先运行 typecheck 和测试，再执行 `pnpm docs:sync --prune`。
 - 只在 `docs/en/` 相对 `main` 真实变化时推送分支。
-- 创建或复用面向 `main` 的同步 PR，并显式 dispatch 该分支的 `Quality gate`。
+- 创建或复用面向 `main` 的同步 PR；维护者批准工作流运行后，由标准 `pull_request` CI 上报 `Quality gate`。
 - 自动 commit、PR 标题和 PR 说明使用中文；PR 说明按真实 Git 差异区分新增、修改和删除，并列出每个 `docs/en` 文件路径。
 - 已存在的同步 PR 会在后续运行时刷新标题和说明，不会保留过期摘要。
 - 当官方内容重新与 `main` 一致时，重置专用分支并关闭已经失效的同步 PR。
 - 不直接 push `main`，因此门禁不需要机器人 bypass。
 - Job 超时为 45 分钟。
 
-仓库已在 **Settings → Actions → General → Workflow permissions** 启用 **Allow GitHub Actions to create and approve pull requests**。`GITHUB_TOKEN` 创建或更新 PR 时会产生 approval-required 的 `pull_request` 事件，因此 `ci.yml` 会把该事件隔离为非门禁 job；同步工作流随后使用允许递归触发的 `workflow_dispatch` 在自动化分支上运行真正的 `Quality gate`。
+仓库已在 **Settings → Actions → General → Workflow permissions** 启用 **Allow GitHub Actions to create and approve pull requests**。`GITHUB_TOKEN` 创建或更新 PR 时会产生 approval-required 的 `pull_request` 事件；维护者批准后，`ci.yml` 会运行固定名称的 `Quality gate` 并满足 `main` Ruleset。
 
 ### 2.5 中文翻译规划基础
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pnpm translate:simulate -- --match guides/agents/quickstart.md --limit 1
 
 ## 自动更新
 
-GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行测试并同步英文 Markdown。只有 `docs/en/` 相对 `main` 实际发生变化时，机器人分支 `automation/sync-openai-docs` 才会创建或更新 PR；机器人不会直接写入 `main`。自动 PR 会显式触发 `Quality gate`，仍需维护者审核并合并。
+GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行测试并同步英文 Markdown。只有 `docs/en/` 相对 `main` 实际发生变化时，机器人分支 `automation/sync-openai-docs` 才会创建或更新 PR；机器人不会直接写入 `main`。自动 PR 仍须在维护者批准工作流运行后通过 `Quality gate`，并由维护者审核合并。
 
 中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，从 `translation-production` 环境读取 `DEEPSEEK_API_KEY`，每轮最多翻译一篇不超过 20,000 个源字符的页面，并通过 `automation/translate-openai-docs` 创建 PR。已有翻译 PR 等待审核时不会继续调用模型。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,7 +96,7 @@ node scripts/sync-docs.ts sync --prune --allow-large-prune
 
 ## 定时任务
 
-`.github/workflows/sync-docs.yml` 每天北京时间 00:00（UTC 16:00）从受信任的 `main` 重建固定分支 `automation/sync-openai-docs`，运行完整同步和 `--prune`，并只提交 `docs/en/` 的真实变化。专用分支使用 `--force-with-lease` 安全更新，工作流不会执行分支自身修改过的脚本。随后创建或更新面向 `main` 的中文 PR；`scripts/sync-pr-summary.ts` 根据实际 Git 差异区分新增、修改和删除，并在 PR 中列出对应文件路径。工作流通过 `workflow_dispatch` 在该分支显式运行 `Quality gate`，不会直接 push `main`。官方内容重新与 `main` 一致时，失效的同步 PR 会被关闭。Job 最长运行 45 分钟，避免上游持续故障或异常 `Retry-After` 无限占用执行器。
+`.github/workflows/sync-docs.yml` 每天北京时间 00:00（UTC 16:00）从受信任的 `main` 重建固定分支 `automation/sync-openai-docs`，运行完整同步和 `--prune`，并只提交 `docs/en/` 的真实变化。专用分支使用 `--force-with-lease` 安全更新，工作流不会执行分支自身修改过的脚本。随后创建或更新面向 `main` 的中文 PR；`scripts/sync-pr-summary.ts` 根据实际 Git 差异区分新增、修改和删除，并在 PR 中列出对应文件路径。维护者批准自动 PR 的工作流运行后，PR 必须通过标准 `pull_request` 触发的 `Quality gate`；工作流不会直接 push `main`。官方内容重新与 `main` 一致时，失效的同步 PR 会被关闭。Job 最长运行 45 分钟，避免上游持续故障或异常 `Retry-After` 无限占用执行器。
 
 首次启用前，需要在仓库 **Settings → Actions → General → Workflow permissions** 勾选 **Allow GitHub Actions to create and approve pull requests**。随后可对 `main` 设置必须通过 PR 和 `Quality gate` 的 Ruleset，无需给同步机器人配置 bypass。
 


### PR DESCRIPTION
## 变更说明

- 将 CI job 固定命名为 `Quality gate`
- 取消自动化 PR 的跳过条件，让必需检查在 `pull_request` 上下文中真实执行
- 删除同步和翻译工作流中无法满足 PR 门禁的额外 `workflow_dispatch`
- 移除不再需要的 `actions: write` 权限并更新文档

## 验证

- YAML 解析通过
- `pnpm typecheck`
- `pnpm test`（58 项通过）
- `pnpm translate:check`
- `pnpm docs:status`
- `git diff --check`