### PR TITLE
[AI] feat: 增加核心文档翻译优先级并提升单轮吞吐

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -28,7 +28,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment: translation-production
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 120
 
     steps:
       - name: Stop while a translation PR is awaiting review
@@ -88,7 +88,7 @@ jobs:
           pnpm test
           pnpm translate:check
 
-      - name: Translate one budgeted page with DeepSeek
+      - name: Translate up to ten budgeted pages with DeepSeek
         if: steps.open-pr.outputs.exists != 'true'
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
@@ -97,7 +97,7 @@ jobs:
             echo "DEEPSEEK_API_KEY is not configured for translation-production." >&2
             exit 1
           fi
-          pnpm translate:auto -- --limit 1
+          pnpm translate:auto -- --limit 10
 
       - name: Publish the translation branch
         if: steps.open-pr.outputs.exists != 'true'
@@ -151,7 +151,7 @@ jobs:
             const body = [
               "## 自动中文翻译",
               "",
-              "本 PR 由受信任的 `main` 工作流使用 DeepSeek 自动生成，每次最多处理一篇受预算约束的页面。",
+              "本 PR 由受信任的 `main` 工作流使用 DeepSeek 自动生成，每次最多处理十篇受预算约束的页面。",
               "",
               "### 文件",
               "",

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -125,7 +125,7 @@ pnpm test
 - render 严格检查 source hash、adapter policy、区间、单元全集、空/多行/控制字符，并在回填后重解析、比较受保护结构签名；恒等翻译测试要求字节级不变。
 - PR #8 合入时交付离线 adapter；PR #9 已在其上合入真实 Provider、首篇译文和 review 流程。
 
-### 2.7 单篇执行器与自动翻译（已合入）
+### 2.7 单篇执行器与批量自动翻译（已合入）
 
 - `runner.ts` 复用 Planner 的同一份安全工作区快照，执行前再次核对英文 SHA 和可翻译状态。
 - Easy Translate Core 负责批次、串行 checkpoint 和恢复；默认 batch=20、concurrency=1、max characters=4000。
@@ -137,7 +137,7 @@ pnpm test
 - provider/model 已进入策略哈希，checkpoint 路径也绑定策略 SHA。`translate:run` 仍限定单篇，默认无写入，只有显式 `--commit` 才落盘。
 - 多行官方导航卡片已纳入受限翻译范围；相邻正文和链接标签共享批次，减少行内链接拆分导致的语序问题。
 - `translate:review` 只接受 `current` 或 `modified-target`，重新核对源、策略和 Markdown 受保护结构后登记人工版本的目标 SHA，并将状态提升为 `reviewed`。
-- `translate:auto -- --limit 1` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 处理；同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序筛选，最后回退到稳定路径排序。每轮一篇并跳过超过 20,000 个源字符的页面。
+- `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 处理；同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序筛选，最后回退到稳定路径排序。每轮最多十篇，每篇都不超过 20,000 个源字符。
 - `translate-docs.yml` 只检出 `main`，先跑离线门禁，再仅向 DeepSeek 步骤注入环境 secret；已有翻译 PR 时停止。它在英文合入后触发，并每天北京时间 01:00 补充运行。
 - CI 已改用 `translate:check`，允许 pending/stale，但拒绝缺失、未登记或被修改而未 review 的目标文件。
 
@@ -176,9 +176,9 @@ pnpm test
 
 ### 后续：积累高价值中文内容并准备静态站
 
-1. 将核心文档优先级配置通过 PR 合入，继续观察 3–5 轮定时自动翻译，确认测试没有持续性偶发失败。
+1. 将核心文档优先级配置和十篇批量翻译通过 PR 合入，继续观察 3–5 轮定时自动翻译，确认测试没有持续性偶发失败。
 2. 优先积累模型、Responses/Chat 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等中文页面；逐篇审核机器译文。
-3. 稳定后评估把每轮吞吐从一篇扩大到 3–5 篇小页面，同时保持字符预算、单一待审核 PR 和完整性门禁。
+3. 稳定后根据模型成本、执行时长和审核负担评估是否继续调整单轮吞吐，同时保持单篇字符预算、单一待审核 PR 和完整性门禁。
 4. 中文核心内容形成后启动静态网站 MVP；不要直接把约 89 MiB、含超大单文件的完整英文镜像交给站点生成器。
 
 ## 5. 新任务开场指令

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 └── .github/workflows/
     ├── ci.yml                # PR、main 与手动触发的质量门禁
     ├── sync-docs.yml         # 每天检查并创建官方更新 PR
-    └── translate-docs.yml    # 受预算约束的单篇自动翻译 PR
+    └── translate-docs.yml    # 受预算约束的批量自动翻译 PR
 ```
 
 英文文件严格按照官网 URL 的路径保存。例如：
@@ -65,11 +65,11 @@ pnpm translate:simulate -- --match guides/agents/quickstart.md --limit 1
 
 GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行测试并同步英文 Markdown。只有 `docs/en/` 相对 `main` 实际发生变化时，机器人分支 `automation/sync-openai-docs` 才会创建或更新 PR；机器人不会直接写入 `main`。自动 PR 仍须在维护者批准工作流运行后通过 `Quality gate`，并由维护者审核合并。
 
-中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，从 `translation-production` 环境读取 `DEEPSEEK_API_KEY`，每轮最多翻译一篇不超过 20,000 个源字符的页面，并通过 `automation/translate-openai-docs` 创建 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。
+中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，从 `translation-production` 环境读取 `DEEPSEEK_API_KEY`，每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。
 
 仓库必须在 **Settings → Actions → General → Workflow permissions** 中启用 **Allow GitHub Actions to create and approve pull requests**。`main` 的 Ruleset 可以因此保持空 bypass，并要求所有更新通过 PR 和 `Quality gate`。
 
-`translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端选择一篇受预算约束的页面；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。静态网站作为核心中文内容形成后的下一阶段推进。
+`translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端按优先级选择最多十篇受预算约束的页面；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。静态网站作为核心中文内容形成后的下一阶段推进。
 
 ## 许可证与内容归属
 

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -6,7 +6,7 @@
 
 本仓库负责 Markdown 结构保护、英文/中文路径映射、术语与提示词、翻译 manifest、增量选择和文档级质量门。批处理、并发、Provider 输出校验、重试、checkpoint、进度和取消复用已发布的 `@easy-translate/core`；OpenAI 与兼容接口复用 `@easy-translate/providers`。本仓库不复制 Provider 或通用翻译引擎。
 
-当前实现提供离线的 `translate:status`、`translate:check`、`translate:plan`、Markdown adapter 和单篇 `translate:simulate`；另提供严格限定单篇的 `translate:run`，以及供受信任远端 workflow 使用的受预算约束 `translate:auto`，两者通过 `@easy-translate/providers` 接入 DeepSeek。simulate 不调用模型、不读取 API key，也不写入 `docs/zh`。
+当前实现提供离线的 `translate:status`、`translate:check`、`translate:plan`、Markdown adapter 和单篇 `translate:simulate`；另提供严格限定单篇的 `translate:run`，以及供受信任远端 workflow 使用的受预算约束批量 `translate:auto`，两者通过 `@easy-translate/providers` 接入 DeepSeek。simulate 不调用模型、不读取 API key，也不写入 `docs/zh`。
 
 ## 目录与持久化契约
 
@@ -89,7 +89,7 @@ Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` �
 2. **Markdown adapter（已完成）**：source-position 提取/还原、保护不变量、fixture 测试，并对齐 `@easy-translate/core` 的 `DocumentAdapter`。
 3. **本地翻译执行器（已完成）**：Core、checkpoint、单篇选择、质量策略、DeepSeek profile 和显式原子提交。
 4. **质量与人工校对（已完成基础闭环）**：结构检查、术语检查、显式 review 收录和 stale 传播；后续补充未登记文件的 adopt 流程。
-5. **自动翻译 PR（已完成首轮生产验收）**：英文变化合入 `main` 后立即触发，并每天补充执行；每轮一篇、20,000 源字符上限、单一待审核 PR，继续服从 `Quality gate` 和 `main` Ruleset。
+5. **自动翻译 PR（已完成首轮生产验收）**：英文变化合入 `main` 后立即触发，并每天补充执行；每轮最多十篇、单篇 20,000 源字符上限、单一待审核 PR，继续服从 `Quality gate` 和 `main` Ruleset。
 6. **内容积累（当前）**：按核心文档优先级积累中文页面，观察流水线稳定性后再扩大单轮吞吐。
 
 任何阶段都不得把模型凭据写入仓库，也不得直接 push `main`。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -141,6 +141,6 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `.github/workflows/translate-docs.yml` 在 `docs/en` 变更合入 `main` 后触发，并每天北京时间 01:00（UTC 17:00）补充运行。工作流只检出受信任的 `main`，在类型检查、测试和 `translate:check` 全部通过后，才把 `translation-production` 环境中的 `DEEPSEEK_API_KEY` 注入翻译步骤。
 
-`translate:auto -- --limit 1` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多一篇，并跳过超过 20,000 个源字符的页面。生成结果只推送到 `automation/translate-openai-docs` 并创建 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
+`translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多十篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
 CI 使用完全离线的 `translate:check` 验证 translation manifest；它允许尚未翻译或因英文更新而 stale 的页面存在，但拒绝 `missing-target`、`untracked-target` 和 `modified-target`。自动 PR 仍需通过 `Quality gate` 和 `main` Ruleset。

--- a/scripts/tests/translation-planner.test.ts
+++ b/scripts/tests/translation-planner.test.ts
@@ -574,19 +574,20 @@ test("translation CLI parses filters without changing defaults", () => {
     matches: [],
     section: "all",
   });
-  assert.deepEqual(parseCliOptions(["auto", "--limit", "1"]), {
+  assert.deepEqual(parseCliOptions(["auto", "--limit", "10"]), {
     command: "auto",
     commit: false,
     configPath: "scripts/translation.config.json",
-    limit: 1,
+    limit: 10,
     matches: [],
     section: "all",
   });
-  assert.throws(() => parseCliOptions(["auto"]), /--limit 1/u);
+  assert.throws(() => parseCliOptions(["auto"]), /--limit 10/u);
   assert.throws(
-    () => parseCliOptions(["auto", "--limit", "1", "--match", "page"]),
+    () => parseCliOptions(["auto", "--limit", "10", "--match", "page"]),
     /不允许 --match/u,
   );
+  assert.throws(() => parseCliOptions(["auto", "--limit", "1"]), /--limit 10/u);
 });
 
 test("automatic selection prioritizes stale work and integrity rejects target drift", () => {

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -30,6 +30,9 @@ import type { MarkdownTranslationContext } from "../translation/markdown-adapter
 const SOURCE_URL = "https://developers.openai.com/api/docs/quickstart.md";
 const SOURCE_PATH = "docs/en/api/docs/quickstart.md";
 const TARGET_PATH = "docs/zh/api/docs/quickstart.md";
+const SECOND_SOURCE_URL = "https://developers.openai.com/api/docs/models.md";
+const SECOND_SOURCE_PATH = "docs/en/api/docs/models.md";
+const SECOND_TARGET_PATH = "docs/zh/api/docs/models.md";
 const DEFAULT_SOURCE = "# Hello OpenAI\n\nRequest API data.\n";
 
 function sha256(content: string): string {
@@ -143,6 +146,52 @@ test("runner commits the page first and a traceable manifest second", async () =
 
     const refreshed = await loadTranslationWorkspace(root);
     assert.equal(refreshed.entries[0]?.state, "current");
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("runner accumulates manifest records across a batch using one workspace snapshot", async () => {
+  const root = await createFixture();
+  try {
+    await writeFile(join(root, SECOND_SOURCE_PATH), DEFAULT_SOURCE);
+    const sourceManifestPath = join(root, "docs/en/.source-manifest.json");
+    const sourceManifest = JSON.parse(
+      await readFile(sourceManifestPath, "utf8"),
+    ) as {
+      pages: Record<string, Record<string, unknown>>;
+    };
+    sourceManifest.pages[SECOND_SOURCE_URL] = {
+      localPath: SECOND_SOURCE_PATH,
+      section: "guides",
+      sha256: sha256(DEFAULT_SOURCE),
+      sourceUrl: SECOND_SOURCE_URL,
+      status: "active",
+    };
+    await writeFile(sourceManifestPath, JSON.stringify(sourceManifest));
+
+    const workspace = await loadTranslationWorkspace(root);
+    await runTranslationPage(workspace, SOURCE_URL, {
+      commit: true,
+      provider: translatedProvider(),
+      useCheckpoint: false,
+    });
+    await runTranslationPage(workspace, SECOND_SOURCE_URL, {
+      commit: true,
+      provider: translatedProvider(),
+      useCheckpoint: false,
+    });
+
+    const manifest = JSON.parse(
+      await readFile(join(root, "docs/zh/.translation-manifest.json"), "utf8"),
+    ) as { pages: Record<string, { targetPath: string }> };
+    assert.equal(manifest.pages[SOURCE_URL]?.targetPath, TARGET_PATH);
+    assert.equal(
+      manifest.pages[SECOND_SOURCE_URL]?.targetPath,
+      SECOND_TARGET_PATH,
+    );
+    await readFile(join(root, TARGET_PATH), "utf8");
+    await readFile(join(root, SECOND_TARGET_PATH), "utf8");
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -41,9 +41,14 @@ interface CliOptions {
   section: SourceSection | "all";
 }
 
+type SourcedTranslationPageInspection = TranslationPageInspection & {
+  source: NonNullable<TranslationPageInspection["source"]>;
+};
+
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_CONFIG_PATH = "scripts/translation.config.json";
 const AUTO_MAX_SOURCE_CHARACTERS = 20_000;
+const AUTO_PAGE_LIMIT = 10;
 const TRANSLATABLE_STATES = new Set<TranslationPageState>([
   "missing-target",
   "pending",
@@ -134,9 +139,13 @@ export function parseCliOptions(argv: string[]): CliOptions {
   }
   if (
     options.command === "auto" &&
-    (options.limit !== 1 || options.matches.length > 0 || options.commit)
+    (options.limit !== AUTO_PAGE_LIMIT ||
+      options.matches.length > 0 ||
+      options.commit)
   ) {
-    throw new Error("auto 必须提供 --limit 1，且不允许 --match 或 --commit。");
+    throw new Error(
+      `auto 必须提供 --limit ${AUTO_PAGE_LIMIT}，且不允许 --match 或 --commit。`,
+    );
   }
   return options;
 }
@@ -350,8 +359,10 @@ async function auto(
   options: CliOptions,
 ): Promise<void> {
   const priority = await loadTranslationPriorityConfig(workspace);
-  let selected: TranslationPageInspection | undefined;
-  let sourceCharacters = 0;
+  const selected: Array<{
+    entry: SourcedTranslationPageInspection;
+    sourceCharacters: number;
+  }> = [];
   for (const entry of automaticTranslationCandidates(
     workspace.entries,
     options.section,
@@ -364,33 +375,47 @@ async function auto(
       "自动翻译英文页面",
     );
     if (source.length <= AUTO_MAX_SOURCE_CHARACTERS) {
-      selected = entry;
-      sourceCharacters = source.length;
-      break;
+      selected.push({
+        entry: { ...entry, source: entry.source },
+        sourceCharacters: source.length,
+      });
+      if (selected.length === options.limit) break;
+      continue;
     }
     console.log(
       `跳过超出自动预算的页面：${entry.source.sourcePath} (${source.length} > ${AUTO_MAX_SOURCE_CHARACTERS})`,
     );
   }
-  if (!selected?.source) {
+  if (selected.length === 0) {
     console.log("自动翻译：没有符合状态与字符预算的页面。");
     return;
   }
-  const result = await runTranslationPage(workspace, selected.source.sourceUrl, {
-    commit: true,
-    provider: createConfiguredProvider(workspace.config.provider),
-    useCheckpoint: false,
-  });
-  console.log(`自动翻译页面：${result.sourceUrl}`);
-  console.log(`state=${selected.state}`);
-  const priorityIndex = priority.sourcePaths.indexOf(selected.source.sourcePath);
-  console.log(`priority=${priorityIndex >= 0 ? priorityIndex + 1 : "fallback"}`);
-  console.log(`source=${selected.source.sourcePath}`);
-  console.log(`target=${result.targetPath}`);
-  console.log(`sourceCharacters=${sourceCharacters}`);
-  console.log(`units=${result.result.stats.uniqueUnits}`);
-  console.log(`characters=${result.result.stats.characters}`);
-  console.log("写入：是（译文及 manifest，reviewStatus=machine）");
+  const provider = createConfiguredProvider(workspace.config.provider);
+  for (const [index, selection] of selected.entries()) {
+    const result = await runTranslationPage(
+      workspace,
+      selection.entry.source.sourceUrl,
+      {
+        commit: true,
+        provider,
+        useCheckpoint: false,
+      },
+    );
+    console.log(`自动翻译页面：${result.sourceUrl}`);
+    console.log(`page=${index + 1}/${selected.length}`);
+    console.log(`state=${selection.entry.state}`);
+    const priorityIndex = priority.sourcePaths.indexOf(
+      selection.entry.source.sourcePath,
+    );
+    console.log(`priority=${priorityIndex >= 0 ? priorityIndex + 1 : "fallback"}`);
+    console.log(`source=${selection.entry.source.sourcePath}`);
+    console.log(`target=${result.targetPath}`);
+    console.log(`sourceCharacters=${selection.sourceCharacters}`);
+    console.log(`units=${result.result.stats.uniqueUnits}`);
+    console.log(`characters=${result.result.stats.characters}`);
+    console.log("写入：是（译文及 manifest，reviewStatus=machine）");
+  }
+  console.log(`自动翻译完成：translated=${selected.length}`);
 }
 
 async function review(


### PR DESCRIPTION
## 变更

- 更新流水线当前状态与后续计划
- 新增 40 篇核心文档优先级配置
- 保持 stale/missing 状态优先，同一状态内按核心清单排序
- 让 `translate:plan` 展示相同队列，并由 `translate:check` 校验配置
- 将自动翻译调整为每轮最多 10 篇，每篇仍限制 20,000 个源字符
- 将翻译工作流超时调整为 120 分钟
- 将翻译配置 schema 升级到 v2

## 验证

- `pnpm typecheck`
- `pnpm test`（61/61）
- `pnpm translate:check`
- `pnpm translate:plan -- --limit 12`