### PR TITLE
[AI] fix: 修复定时任务并增加翻译重试

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 > **给后续执行者：** 官方英文同步、自动中文翻译、PR 质量门禁和首轮生产验收均已闭环。当前重点是按高价值文档优先级积累中文内容并观察流水线稳定性；不要恢复旧 Python 翻译脚本，不要清洗 `docs/en`，也不要让自动任务覆盖未登记或人工修改的中文文件。
 
-**更新时间：** 2026-08-25（Asia/Singapore）
+**更新时间：** 2026-08-26（Asia/Singapore）
 
 ## 1. 当前阶段结论
 
@@ -13,7 +13,7 @@
 - 翻译规划与 Markdown adapter PR #8 已合入；自动翻译 runner、DeepSeek profile、review/auto 流程和远端 workflow PR #9 已合入。
 - 自动 PR 质量门禁修复 PR #12 已合入。
 - 首轮生产自动翻译成功创建 PR #13，`Quality gate` 最终通过，PR 合入后的 `main` CI 也成功。
-- 当前中文状态：2 current、419 pending；首篇 Agents quickstart 为 `reviewed`，自动生成的 Actions Library 为 `machine`。
+- 当前中文状态：3 current、418 pending；首篇 Agents quickstart 为 `reviewed`，自动生成的页面为 `machine`。
 - 本地与远端仅 `translate:run`、`translate:auto` 会读取 `DEEPSEEK_API_KEY`；key 不进入仓库、日志、checkpoint 或 manifest。
 - 核心文档优先级由 `scripts/translation/priority.zh-CN.json` 维护；同一状态内优先处理配置清单，stale/missing 维护任务仍先于 pending。
 
@@ -131,6 +131,8 @@ pnpm test
 - Easy Translate Core 负责批次、串行 checkpoint 和恢复；默认 batch=20、concurrency=1、max characters=4000。
 - checkpoint 写入被忽略的 `.cache/translation-checkpoints/`，使用临时文件与原子 rename。
 - 单元质量策略检查 preserve 术语、指定译法和占位符数量；Markdown adapter 在整篇 render 后继续检查结构、代码和 URL。
+- 生产 Provider 会按最长匹配将 `preserve` 术语替换为批次内唯一占位符，模型返回后逐字恢复；质量策略仍会独立复核，避免术语保护只依赖提示词。
+- 批次对格式、质量和可重试 Provider 错误最多重试 2 次，采用指数退避与 jitter；批次耗尽后页面等待约 10–12 秒并基于 checkpoint 额外恢复 1 次。认证、配置、路径和完整性错误不重试，日志包含页面、单元、原因和等待时间。
 - 提交前重新加载工作区，拒绝竞态变化；按“先译文、后 manifest”写入。中断只会留下可检测并阻塞覆盖的 `untracked-target` 或 `modified-target`。
 - `translate:simulate` 必须同时提供 `--match` 和 `--limit 1`，使用 Echo/Fake Provider，不写译文、manifest 或 checkpoint。
 - 已接入 `@easy-translate/providers@0.1.0` 的 DeepSeek profile；默认模型 `deepseek-chat`，key 只读 `DEEPSEEK_API_KEY`。
@@ -140,20 +142,22 @@ pnpm test
 - `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 处理；同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序筛选，最后回退到稳定路径排序。每轮最多十篇，每篇都不超过 20,000 个源字符。
 - `translate-docs.yml` 只检出 `main`，先跑离线门禁，再仅向 DeepSeek 步骤注入环境 secret；已有翻译 PR 时停止。它在英文合入后触发，并每天北京时间 01:00 补充运行。
 - CI 已改用 `translate:check`，允许 pending/stale，但拒绝缺失、未登记或被修改而未 review 的目标文件。
+- Node 测试固定使用 `--test-isolation=none`，规避 Node 24 子进程 IPC 偶发的 cloned data 反序列化失败；测试仍保持单并发。
 
 ## 3. 当前验证证据
 
-2026-08-25 翻译规划、Markdown adapter、runner 与自动化验证：
+2026-08-26 翻译规划、Markdown adapter、runner 与自动化验证：
 
 - `pnpm typecheck`：通过。
-- `pnpm test`：60/60 通过（包含 planner、provider、runner、优先级配置与选择、review 结构保护及既有同步/adapter 测试）。
+- `pnpm test`：63/63 通过（包含 planner、provider、runner、优先级配置与选择、review 结构保护及既有同步/adapter 测试）。
 - `pnpm docs:status`：421 active、0 removed、89.0 MiB。
-- `pnpm translate:status`：2 current、419 pending，其他状态为 0。
+- `pnpm translate:check`：通过；3 current、418 pending，其他阻塞状态为 0。
 - `pnpm translate:plan -- --limit 12`：按核心文档清单优先列出模型、API 概览、文本生成、流式输出、后台任务、Code Interpreter、生产最佳实践和 Realtime 文档。
 - 定向测试覆盖路径/符号链接越界、八种状态及安全优先级、策略 stale、未登记/人工修改保护、源 SHA 脏改动拒绝、重复路径、manifest 时间/版本契约、术语冲突和 orphan 记录保留。
 - Markdown adapter 定向测试覆盖恒等字节不变、标题/正文/列表/引用/表格、链接标签、图片 alt、代码/HTML/MDX/frontmatter/URL 保护、跨行容器标记、无效结果和区间篡改拒绝。
-- Runner 定向测试覆盖无写入模拟、安全提交、checkpoint 中断恢复、阻塞状态、符号链接/非规范路径写入拒绝、术语和占位符保护。
-- `pnpm translate:simulate -- --match guides/agents/quickstart.md --limit 1`：完成 53 个单元、2403 个字符的无 key 单篇闭环，写入为 0。
+- Runner 定向测试覆盖无写入模拟、安全提交、checkpoint 中断恢复、批次耗尽后的页面恢复、阻塞状态、符号链接/非规范路径写入拒绝、术语和占位符保护。
+- Provider 定向测试覆盖最长术语优先掩码和返回后的逐字恢复。
+- `pnpm translate:simulate -- --match api/reference/overview.md --limit 1`：完成 115 个单元、5305 个字符的无 key 单篇闭环，写入为 0。
 - 6 篇真实官方 guides/reference 样本（合计约 251 KiB，包含 MDX、表格与多语言代码）完成 prepare + 恒等 render，输出逐字节一致。
 - CI 已增加完全离线的 `pnpm translate:check`。
 
@@ -176,7 +180,7 @@ pnpm test
 
 ### 后续：积累高价值中文内容并准备静态站
 
-1. 将核心文档优先级配置和十篇批量翻译通过 PR 合入，继续观察 3–5 轮定时自动翻译，确认测试没有持续性偶发失败。
+1. 将本轮定时任务稳定性修复通过 PR 合入，继续观察 3–5 轮自动同步与翻译，确认 Node 测试和 DeepSeek 质量门不再持续性失败。
 2. 优先积累模型、Responses/Chat 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等中文页面；逐篇审核机器译文。
 3. 稳定后根据模型成本、执行时长和审核负担评估是否继续调整单轮吞吐，同时保持单篇字符预算、单一待审核 PR 和完整性门禁。
 4. 中文核心内容形成后启动静态网站 MVP；不要直接把约 89 MiB、含超大单文件的完整英文镜像交给站点生成器。

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pnpm translate:simulate -- --match guides/agents/quickstart.md --limit 1
 
 GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行测试并同步英文 Markdown。只有 `docs/en/` 相对 `main` 实际发生变化时，机器人分支 `automation/sync-openai-docs` 才会创建或更新 PR；机器人不会直接写入 `main`。自动 PR 仍须在维护者批准工作流运行后通过 `Quality gate`，并由维护者审核合并。
 
-中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，从 `translation-production` 环境读取 `DEEPSEEK_API_KEY`，每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。
+中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，从 `translation-production` 环境读取 `DEEPSEEK_API_KEY`，每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
 
 仓库必须在 **Settings → Actions → General → Workflow permissions** 中启用 **Allow GitHub Actions to create and approve pull requests**。`main` 的 Ruleset 可以因此保持空 bypass，并要求所有更新通过 PR 和 `Quality gate`。
 

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -73,7 +73,7 @@ render 拒绝缺失或多余单元、空文本、换行/控制字符、被篡改
 
 - 文档级选择由源 SHA 和 `policySha256` 决定。
 - 自动队列先按 `stale-source`、`stale-policy`、`missing-target`、`pending` 维护状态排序；同一状态内按版本化的核心文档清单排序，未列入清单的页面按稳定路径回退。选择优先级不改变译文内容，因此不参与 `policySha256`。
-- 单篇文档内部使用 Easy Translate checkpoint；只有整篇 render 和质量检查成功后才原子更新译文与 manifest。
+- 单篇文档内部使用 Easy Translate checkpoint；批次对格式、质量和可重试 Provider 错误做有限指数退避，批次耗尽后页面可从 checkpoint 额外恢复一次。认证、配置、路径和完整性错误不重试。只有整篇 render 和质量检查成功后才原子更新译文与 manifest。
 - 批量任务默认低并发，先支持 `--section`、`--match` 和 `--limit`，再开放全量运行。
 - 质量检查至少覆盖：Markdown 可重新解析、保护内容一致、无空译文、链接目标一致、代码块一致、manifest/文件 SHA 一致。
 - 机器译文以 PR 形式进入 `main`；人工校对只提升 `reviewStatus`，英文或策略变化后仍会重新标记 stale。
@@ -81,7 +81,7 @@ render 拒绝缺失或多余单元、空文本、换行/控制字符、被篡改
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 
-真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
+真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配替换为批次内唯一占位符，响应后再逐字恢复，质量策略仍会独立复核术语与占位符。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
 
 ## 分阶段交付
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs:check": "node scripts/sync-docs.ts check",
     "docs:status": "node scripts/sync-docs.ts status",
     "docs:sync": "node scripts/sync-docs.ts sync",
-    "test": "node --test --test-concurrency=1 scripts/tests/*.test.ts",
+    "test": "node --test --test-concurrency=1 --test-isolation=none scripts/tests/*.test.ts",
     "translate:auto": "node --env-file-if-exists=.env scripts/translate-docs.ts auto",
     "translate:check": "node scripts/translate-docs.ts check",
     "translate:plan": "node scripts/translate-docs.ts plan",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,4 +143,6 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多十篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
+生产翻译采用分层恢复：术语表的 `preserve` 项在发送前替换为唯一占位符，模型返回后再逐字恢复；每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间。批次仍失败时，整页等待 10–12 秒后额外恢复 1 次，已完成批次从 Git 忽略的 checkpoint 继续，不重复调用。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
+
 CI 使用完全离线的 `translate:check` 验证 translation manifest；它允许尚未翻译或因英文更新而 stale 的页面存在，但拒绝 `missing-target`、`untracked-target` 和 `modified-target`。自动 PR 仍需通过 `Quality gate` 和 `main` Ruleset。

--- a/scripts/tests/translation-provider.test.ts
+++ b/scripts/tests/translation-provider.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createConfiguredProvider } from "../translation/provider.ts";
+import { defineProvider } from "@easy-translate/core";
+
+import {
+  createConfiguredProvider,
+  createPreserveTermsProvider,
+} from "../translation/provider.ts";
 import type { TranslationProviderProfile } from "../translation/types.ts";
 
 const PROFILE: TranslationProviderProfile = {
@@ -19,4 +24,35 @@ test("configured DeepSeek provider requires its key without exposing credentials
   assert.doesNotThrow(() =>
     createConfiguredProvider(PROFILE, { DEEPSEEK_API_KEY: secret }),
   );
+});
+
+test("preserve-term provider masks longest matches and restores exact terms", async () => {
+  let observedText = "";
+  const provider = defineProvider({
+    async translateBatch(request) {
+      observedText = request.items[0]?.text ?? "";
+      return request.items.map((item) => ({
+        id: item.id,
+        text: item.text.replace(" and ", " 与 "),
+      }));
+    },
+  });
+  const protectedProvider = createPreserveTermsProvider(provider, [
+    "API",
+    "Responses API",
+  ]);
+  const output = await protectedProvider.translateBatch({
+    items: [
+      {
+        context: {},
+        id: "unit",
+        text: "Responses API and API",
+      },
+    ],
+    targetLanguage: "zh-CN",
+  });
+
+  assert.equal(observedText.includes("API"), false);
+  assert.equal(observedText.match(/\{\{ET_KEEP_/gu)?.length, 2);
+  assert.equal(output[0]?.text, "Responses API 与 API");
 });

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -15,6 +15,8 @@ import test from "node:test";
 import {
   createEchoProvider,
   defineProvider,
+  TranslationErrorCode,
+  TranslationResponseError,
   type TranslationProvider,
 } from "@easy-translate/core";
 
@@ -24,6 +26,7 @@ import {
   createTranslationQualityPolicy,
   reviewTranslationPage,
   runTranslationPage,
+  runTranslationPageWithRetry,
 } from "../translation/runner.ts";
 import type { MarkdownTranslationContext } from "../translation/markdown-adapter.ts";
 
@@ -292,6 +295,52 @@ test("runner resumes from the last serialized checkpoint", async () => {
     assert.equal(run.result.stats.fromCheckpointUnits, 1);
     assert.equal(resumedCalls, run.result.stats.uniqueUnits - 1);
     assert.equal(run.rendered, "# One\n\nTwo.\n\nThree.\n");
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("page retry resumes its checkpoint after batch retries are exhausted", async () => {
+  const root = await createFixture("# One\n\nTwo.\n\nThree.\n");
+  try {
+    const workspace = await loadTranslationWorkspace(root);
+    let calls = 0;
+    const provider = defineProvider<MarkdownTranslationContext>({
+      async translateBatch(request) {
+        calls += 1;
+        if (calls === 2) {
+          throw new TranslationResponseError(
+            TranslationErrorCode.ResponseQualityRejected,
+            "simulated quality failure",
+          );
+        }
+        return request.items.map((item) => ({ id: item.id, text: item.text }));
+      },
+    });
+    const pageRetries: number[] = [];
+    const run = await runTranslationPageWithRetry(workspace, SOURCE_URL, {
+      batchSize: 1,
+      concurrency: 1,
+      pageRetry: {
+        baseDelayMs: 0,
+        jitterMs: 0,
+        maxDelayMs: 0,
+        maxRetries: 1,
+        onRetry: (event) => {
+          pageRetries.push(event.attempt);
+        },
+        runtime: {
+          random: () => 0,
+          sleep: async () => undefined,
+        },
+      },
+      provider,
+      retry: 0,
+    });
+
+    assert.deepEqual(pageRetries, [1]);
+    assert.equal(run.result.stats.fromCheckpointUnits, 1);
+    assert.equal(calls, run.result.stats.uniqueUnits + 1);
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -3,7 +3,14 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { createEchoProvider } from "@easy-translate/core";
+import {
+  createEchoProvider,
+  isTranslationCoreError,
+  type RetryOperationOptions,
+  type TranslationProvider,
+  type TranslationRetryEvent,
+  type TranslationRetryPolicy,
+} from "@easy-translate/core";
 
 import {
   loadTranslationWorkspace,
@@ -12,6 +19,7 @@ import {
 import {
   reviewTranslationPage,
   runTranslationPage,
+  runTranslationPageWithRetry,
 } from "./translation/runner.ts";
 import { createConfiguredProvider } from "./translation/provider.ts";
 import { loadTranslationPriorityConfig } from "./translation/priority.ts";
@@ -49,6 +57,18 @@ const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_CONFIG_PATH = "scripts/translation.config.json";
 const AUTO_MAX_SOURCE_CHARACTERS = 20_000;
 const AUTO_PAGE_LIMIT = 10;
+const TRANSLATION_BATCH_RETRY_POLICY = {
+  baseDelayMs: 1_000,
+  jitterMs: 250,
+  maxDelayMs: 8_000,
+  maxRetries: 2,
+} satisfies TranslationRetryPolicy;
+const TRANSLATION_PAGE_RETRY_POLICY = {
+  baseDelayMs: 10_000,
+  jitterMs: 2_000,
+  maxDelayMs: 15_000,
+  maxRetries: 1,
+} satisfies TranslationRetryPolicy;
 const TRANSLATABLE_STATES = new Set<TranslationPageState>([
   "missing-target",
   "pending",
@@ -59,6 +79,72 @@ const BLOCKED_STATES = new Set<TranslationPageState>([
   "modified-target",
   "untracked-target",
 ]);
+
+interface ProductionTranslationPage {
+  sourcePath: string;
+  sourceUrl: string;
+  targetPath: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function translationUnitId(error: unknown): string | undefined {
+  if (!isTranslationCoreError(error)) return undefined;
+  const unitId = error.details.unitId;
+  return typeof unitId === "string" && unitId ? unitId : undefined;
+}
+
+function logRetry(
+  level: "batch" | "page",
+  page: ProductionTranslationPage,
+  event: TranslationRetryEvent,
+): void {
+  const maximum =
+    level === "batch"
+      ? TRANSLATION_BATCH_RETRY_POLICY.maxRetries
+      : TRANSLATION_PAGE_RETRY_POLICY.maxRetries;
+  const unitId = translationUnitId(event.error);
+  console.warn(
+    `翻译${level === "batch" ? "批次" : "页面"}重试：source=${page.sourcePath} ` +
+      `retry=${event.attempt}/${maximum} reason=${event.reason} delay=${event.delayMs}ms` +
+      `${unitId ? ` unit=${unitId}` : ""}；${errorMessage(event.error)}`,
+  );
+}
+
+function translationFailure(page: ProductionTranslationPage, error: unknown): Error {
+  const code = isTranslationCoreError(error) ? ` code=${error.code}` : "";
+  const unitId = translationUnitId(error);
+  return new Error(
+    `翻译页面最终失败：source=${page.sourcePath} target=${page.targetPath}${code}` +
+      `${unitId ? ` unit=${unitId}` : ""}；${errorMessage(error)}`,
+    { cause: error },
+  );
+}
+
+async function runProductionTranslationPage(
+  workspace: TranslationWorkspaceSnapshot,
+  page: ProductionTranslationPage,
+  provider: TranslationProvider<MarkdownTranslationContext>,
+  commit: boolean,
+) {
+  const pageRetry: RetryOperationOptions = {
+    ...TRANSLATION_PAGE_RETRY_POLICY,
+    onRetry: (event) => logRetry("page", page, event),
+  };
+  try {
+    return await runTranslationPageWithRetry(workspace, page.sourceUrl, {
+      commit,
+      onRetry: (event) => logRetry("batch", page, event),
+      pageRetry,
+      provider,
+      retry: TRANSLATION_BATCH_RETRY_POLICY,
+    });
+  } catch (error) {
+    throw translationFailure(page, error);
+  }
+}
 
 function parsePositiveInteger(value: string | undefined, option: string): number {
   const parsed = Number(value);
@@ -340,10 +426,21 @@ async function run(
   if (!TRANSLATABLE_STATES.has(entries[0].state)) {
     throw new Error(`页面状态 ${entries[0].state} 阻塞真实翻译。`);
   }
-  const result = await runTranslationPage(workspace, entries[0].source.sourceUrl, {
-    commit: options.commit,
-    provider: createConfiguredProvider(workspace.config.provider),
-  });
+  const page = {
+    sourcePath: entries[0].source.sourcePath,
+    sourceUrl: entries[0].source.sourceUrl,
+    targetPath: entries[0].targetPath,
+  };
+  const result = await runProductionTranslationPage(
+    workspace,
+    page,
+    createConfiguredProvider(
+      workspace.config.provider,
+      process.env,
+      workspace.glossary.preserve,
+    ),
+    options.commit,
+  );
   console.log(`翻译页面：${result.sourceUrl}`);
   console.log(`provider=${workspace.config.provider.id}`);
   console.log(`model=${workspace.config.provider.model}`);
@@ -390,16 +487,21 @@ async function auto(
     console.log("自动翻译：没有符合状态与字符预算的页面。");
     return;
   }
-  const provider = createConfiguredProvider(workspace.config.provider);
+  const provider = createConfiguredProvider(
+    workspace.config.provider,
+    process.env,
+    workspace.glossary.preserve,
+  );
   for (const [index, selection] of selected.entries()) {
-    const result = await runTranslationPage(
+    const result = await runProductionTranslationPage(
       workspace,
-      selection.entry.source.sourceUrl,
       {
-        commit: true,
-        provider,
-        useCheckpoint: false,
+        sourcePath: selection.entry.source.sourcePath,
+        sourceUrl: selection.entry.source.sourceUrl,
+        targetPath: selection.entry.targetPath,
       },
+      provider,
+      true,
     );
     console.log(`自动翻译页面：${result.sourceUrl}`);
     console.log(`page=${index + 1}/${selected.length}`);

--- a/scripts/translation/provider.ts
+++ b/scripts/translation/provider.ts
@@ -1,12 +1,100 @@
 import { createDeepSeekProvider } from "@easy-translate/providers";
-import type { TranslationProvider } from "@easy-translate/core";
+import type {
+  TranslationBatchRequest,
+  TranslationProvider,
+} from "@easy-translate/core";
 
 import type { MarkdownTranslationContext } from "./markdown-adapter.ts";
 import type { TranslationProviderProfile } from "./types.ts";
 
+interface PreserveReplacement {
+  term: string;
+  token: string;
+}
+
+function protectPreserveTerms(
+  text: string,
+  terms: readonly string[],
+  requestIndex: number,
+  itemIndex: number,
+): { replacements: PreserveReplacement[]; text: string } {
+  let protectedText = text;
+  const replacements: PreserveReplacement[] = [];
+  for (const [termIndex, term] of terms.entries()) {
+    if (!protectedText.includes(term)) continue;
+    let tokenIndex = termIndex;
+    let token = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}}}`;
+    while (protectedText.includes(token)) {
+      tokenIndex += terms.length;
+      token = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}}}`;
+    }
+    protectedText = protectedText.split(term).join(token);
+    replacements.push({ term, token });
+  }
+  return { replacements, text: protectedText };
+}
+
+function restorePreserveTerms(
+  text: string,
+  replacements: readonly PreserveReplacement[],
+): string {
+  let restored = text;
+  for (const replacement of replacements) {
+    restored = restored.split(replacement.token).join(replacement.term);
+  }
+  return restored;
+}
+
+export function createPreserveTermsProvider<TContext>(
+  provider: TranslationProvider<TContext>,
+  preserveTerms: readonly string[],
+): TranslationProvider<TContext> {
+  const terms = [...preserveTerms].sort(
+    (left, right) => right.length - left.length || left.localeCompare(right, "en"),
+  );
+  if (terms.length === 0) return provider;
+
+  let requestIndex = 0;
+  return {
+    name: provider.name,
+    async translateBatch(request, signal, onActivity) {
+      const currentRequest = requestIndex;
+      requestIndex += 1;
+      const replacementsById = new Map<string, PreserveReplacement[]>();
+      const items = request.items.map((item, itemIndex) => {
+        const protectedItem = protectPreserveTerms(
+          item.text,
+          terms,
+          currentRequest,
+          itemIndex,
+        );
+        replacementsById.set(item.id, protectedItem.replacements);
+        return { ...item, text: protectedItem.text };
+      });
+      const protectedRequest: TranslationBatchRequest<TContext> = {
+        ...request,
+        items,
+      };
+      const output = await provider.translateBatch(
+        protectedRequest,
+        signal,
+        onActivity,
+      );
+      return output.map((item) => ({
+        ...item,
+        text: restorePreserveTerms(
+          item.text,
+          replacementsById.get(item.id) ?? [],
+        ),
+      }));
+    },
+  };
+}
+
 export function createConfiguredProvider(
   profile: TranslationProviderProfile,
   environment: NodeJS.ProcessEnv = process.env,
+  preserveTerms: readonly string[] = [],
 ): TranslationProvider<MarkdownTranslationContext> {
   const apiKey = environment[profile.apiKeyEnv]?.trim();
   if (!apiKey) {
@@ -14,5 +102,8 @@ export function createConfiguredProvider(
       `缺少环境变量 ${profile.apiKeyEnv}；请在本地配置 DeepSeek API key 后重试。`,
     );
   }
-  return createDeepSeekProvider({ apiKey, model: profile.model });
+  return createPreserveTermsProvider(
+    createDeepSeekProvider({ apiKey, model: profile.model }),
+    preserveTerms,
+  );
 }

--- a/scripts/translation/runner.ts
+++ b/scripts/translation/runner.ts
@@ -20,11 +20,15 @@ import {
 } from "node:path";
 
 import {
+  retryOperation,
   translatePlan,
+  type RetryOperationOptions,
   type TranslationCheckpoint,
   type TranslationProvider,
   type TranslationQualityPolicy,
   type TranslationResult,
+  type TranslationRetryEvent,
+  type TranslationRetryPolicy,
 } from "@easy-translate/core";
 
 import {
@@ -57,10 +61,18 @@ export interface TranslationPageRunOptions {
   concurrency?: number | undefined;
   maxBatchCharacters?: number | undefined;
   now?: (() => Date) | undefined;
+  onRetry?: ((event: TranslationRetryEvent) => void) | undefined;
   provider: TranslationProvider<MarkdownTranslationContext>;
-  retry?: number | undefined;
+  retry?: number | TranslationRetryPolicy | undefined;
   useCheckpoint?: boolean | undefined;
 }
+
+export type RetriableTranslationPageRunOptions = Omit<
+  TranslationPageRunOptions,
+  "useCheckpoint"
+> & {
+  pageRetry?: number | RetryOperationOptions | undefined;
+};
 
 export interface TranslationPageRunResult {
   checkpointPath: string;
@@ -516,6 +528,7 @@ export async function runTranslationPage(
   const path = checkpointPath(entry.source.sourceUrl, workspace.policySha256);
   const useCheckpoint = options.useCheckpoint ?? true;
   const instructions = instructionsForWorkspace(workspace);
+  let lastReportedRetry: TranslationRetryEvent | undefined;
   const result = await translatePlan(prepared.plan, {
     batchSize: options.batchSize ?? 20,
     checkpoint: useCheckpoint
@@ -536,6 +549,19 @@ export async function runTranslationPage(
     provider: options.provider,
     qualityPolicy: createTranslationQualityPolicy(workspace.glossary),
     retry: options.retry ?? 2,
+    onProgress:
+      options.onRetry === undefined
+        ? undefined
+        : (progress) => {
+            if (
+              progress.lastRetry === undefined ||
+              progress.lastRetry === lastReportedRetry
+            ) {
+              return;
+            }
+            lastReportedRetry = progress.lastRetry;
+            options.onRetry?.(progress.lastRetry);
+          },
     sourceLanguage: "en",
     targetLanguage: workspace.targetLanguage,
   });
@@ -565,4 +591,29 @@ export async function runTranslationPage(
     sourceUrl: entry.source.sourceUrl,
     targetPath: entry.targetPath,
   };
+}
+
+export async function runTranslationPageWithRetry(
+  workspace: TranslationWorkspaceSnapshot,
+  sourceUrl: string,
+  options: RetriableTranslationPageRunOptions,
+): Promise<TranslationPageRunResult> {
+  const { pageRetry, ...runOptions } = options;
+  const retryOptions: RetryOperationOptions =
+    typeof pageRetry === "number"
+      ? { maxRetries: pageRetry }
+      : (pageRetry ?? {
+          baseDelayMs: 10_000,
+          jitterMs: 2_000,
+          maxDelayMs: 10_000,
+          maxRetries: 1,
+        });
+  return retryOperation(
+    () =>
+      runTranslationPage(workspace, sourceUrl, {
+        ...runOptions,
+        useCheckpoint: true,
+      }),
+    retryOptions,
+  );
 }


### PR DESCRIPTION
## 变更摘要

- 将 Node 测试切换为无子进程隔离模式，规避 Node 24 偶发的 cloned data 反序列化失败
- 为生产翻译增加 preserve 术语掩码与精确恢复，避免 API 等术语被模型遗漏
- 增加批次级指数退避，以及批次耗尽后的 checkpoint 页面级恢复
- 将仓库指令标准化为 `AGENTS.md`，明确 commit 与 PR/MR 的 `[AI]` / `[Human]` 前缀
- 为 PR 标题增加质量门禁，并同步调整自动同步、自动翻译 PR 标题
- 补充重试上下文日志、定向测试和文档说明

## 验证

- `pnpm typecheck`
- `pnpm test`（65/65）
- `pnpm translate:check`
- `pnpm translate:simulate -- --match api/reference/overview.md --limit 1`
- 三份 GitHub Actions workflow YAML 语法检查