### PR TITLE
[AI] fix: 修复翻译术语边界误判

### DIFF
--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -81,7 +81,7 @@ render 拒绝缺失或多余单元、空文本、换行/控制字符、被篡改
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 
-真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配替换为批次内唯一占位符，响应后再逐字恢复，质量策略仍会独立复核术语与占位符。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
+真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配替换为批次内唯一占位符，响应后再逐字恢复；指定译法只检查完整单词或短语，并排除已整体保留的产品名，质量策略仍会独立复核术语与占位符。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
 
 ## 分阶段交付
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,6 +143,6 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多十篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
-生产翻译采用分层恢复：术语表的 `preserve` 项在发送前替换为唯一占位符，模型返回后再逐字恢复；每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间。批次仍失败时，整页等待 10–12 秒后额外恢复 1 次，已完成批次从 Git 忽略的 checkpoint 继续，不重复调用。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
+生产翻译采用分层恢复：术语表的 `preserve` 项在发送前替换为唯一占位符，模型返回后再逐字恢复；指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间。批次仍失败时，整页等待 10–12 秒后额外恢复 1 次，已完成批次从 Git 忽略的 checkpoint 继续，不重复调用。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
 
 CI 使用完全离线的 `translate:check` 验证 translation manifest；它允许尚未翻译或因英文更新而 stale 的页面存在，但拒绝 `missing-target`、`untracked-target` 和 `modified-target`。自动 PR 仍需通过 `Quality gate` 和 `main` Ruleset。

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -423,3 +423,58 @@ test("quality policy preserves glossary terms and placeholders", async () => {
     "translation.placeholder_changed",
   );
 });
+
+test("quality policy does not match terms inside product names or longer words", async () => {
+  const policy = createTranslationQualityPolicy({
+    preserve: ["Agents SDK"],
+    schemaVersion: 1,
+    terms: {
+      Agent: "智能体",
+      Agents: "智能体",
+      agent: "智能体",
+      agents: "智能体",
+      workflow: "工作流",
+    },
+  });
+  const input = (text: string, translatedText: string) => ({
+    item: {
+      context: {} as MarkdownTranslationContext,
+      id: "unit",
+      text,
+    },
+    plan: {
+      document: { format: "markdown", id: "doc" },
+      schemaVersion: 1 as const,
+      units: [],
+    },
+    request: {
+      items: [],
+      targetLanguage: "zh-CN",
+    },
+    translatedText,
+  });
+
+  assert.equal(
+    await policy(
+      input(
+        "It uses the Agents SDK with WebRTC.",
+        "它通过 WebRTC 使用 Agents SDK。",
+      ),
+    ),
+    undefined,
+  );
+  assert.equal(
+    await policy(input("Agentic workflows evolve.", "Agentic workflows 持续演进。")),
+    undefined,
+  );
+  assert.equal(
+    (await policy(input("An Agent runs a workflow.", "一个代理运行流程。")))
+      ?.issueCode,
+    "translation.term_missing",
+  );
+  assert.equal(
+    (await policy(input("Agents coordinate tools.", "Agents 协调工具。")))
+      ?.issueCode,
+    "translation.term_missing",
+  );
+});

--- a/scripts/translation/glossary.zh-CN.json
+++ b/scripts/translation/glossary.zh-CN.json
@@ -4,12 +4,15 @@
     "OpenAI",
     "API",
     "SDK",
+    "Agents SDK",
     "Chat Completions API",
     "Responses API"
   ],
   "terms": {
     "Agent": "智能体",
+    "Agents": "智能体",
     "agent": "智能体",
+    "agents": "智能体",
     "continuation": "延续",
     "file search": "文件搜索",
     "guardrail": "护栏",

--- a/scripts/translation/runner.ts
+++ b/scripts/translation/runner.ts
@@ -316,6 +316,34 @@ function sortedTokens(content: string): string[] {
     .sort();
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function containsCompleteTerm(content: string, term: string): boolean {
+  const wordCharacter = "[\\p{L}\\p{N}_]";
+  const startsWithWord = /^[\p{L}\p{N}_]/u.test(term);
+  const endsWithWord = /[\p{L}\p{N}_]$/u.test(term);
+  const pattern =
+    `${startsWithWord ? `(?<!${wordCharacter})` : ""}${escapeRegExp(term)}` +
+    `${endsWithWord ? `(?!${wordCharacter})` : ""}`;
+  return new RegExp(pattern, "u").test(content);
+}
+
+function withoutPreservedTerms(
+  content: string,
+  preserveTerms: readonly string[],
+): string {
+  let unprotected = content;
+  const terms = [...preserveTerms].sort(
+    (left, right) => right.length - left.length || left.localeCompare(right, "en"),
+  );
+  for (const term of terms) {
+    unprotected = unprotected.split(term).join(" ".repeat(term.length));
+  }
+  return unprotected;
+}
+
 export function createTranslationQualityPolicy(
   glossary: TranslationGlossary,
 ): TranslationQualityPolicy<MarkdownTranslationContext> {
@@ -336,8 +364,15 @@ export function createTranslationQualityPolicy(
         };
       }
     }
+    const terminologySource = withoutPreservedTerms(
+      item.text,
+      glossary.preserve,
+    );
     for (const [source, target] of Object.entries(glossary.terms)) {
-      if (item.text.includes(source) && !translatedText.includes(target)) {
+      if (
+        containsCompleteTerm(terminologySource, source) &&
+        !translatedText.includes(target)
+      ) {
         return {
           issueCode: "translation.term_missing",
           message: `术语 ${source} 必须翻译为 ${target}。`,


### PR DESCRIPTION
## 变更摘要

- 将 `Agents SDK` 作为完整产品名保留
- 指定译法改为完整单词或短语匹配，并排除整体保留的产品名
- 补充 `Agent/Agents/agent/agents` 术语，普通单复数仍强制翻译为“智能体”
- 增加对应远端失败单元的回归测试并更新翻译设计说明

## 验证

- `pnpm typecheck`
- `pnpm test`（66/66）
- `pnpm translate:check`（完整性通过；策略更新后 3 篇为 `stale-policy`）