### PR TITLE
[AI] fix: 避免拆分片段术语误判

### DIFF
--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -81,7 +81,7 @@ render 拒绝缺失或多余单元、空文本、换行/控制字符、被篡改
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 
-真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配替换为批次内唯一占位符，响应后再逐字恢复；指定译法只检查完整单词或短语，并排除已整体保留的产品名，质量策略仍会独立复核术语与占位符。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
+真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配替换为批次内唯一占位符，响应后再逐字恢复；指定译法只检查完整单词或短语，并排除已整体保留的产品名。质量策略会独立复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制指定译法，因为中文语序可能把术语移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
 
 ## 分阶段交付
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,6 +143,6 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多十篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
-生产翻译采用分层恢复：术语表的 `preserve` 项在发送前替换为唯一占位符，模型返回后再逐字恢复；指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间。批次仍失败时，整页等待 10–12 秒后额外恢复 1 次，已完成批次从 Git 忽略的 checkpoint 继续，不重复调用。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
+生产翻译采用分层恢复：术语表的 `preserve` 项在发送前替换为唯一占位符，模型返回后再逐字恢复；指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。当一个 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，术语表仍随完整批次发送给模型，但质量门不再要求每个片段各自包含目标术语，避免中文调整语序后被误判。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间。批次仍失败时，整页等待 10–12 秒后额外恢复 1 次，已完成批次从 Git 忽略的 checkpoint 继续，不重复调用。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
 
 CI 使用完全离线的 `translate:check` 验证 translation manifest；它允许尚未翻译或因英文更新而 stale 的页面存在，但拒绝 `missing-target`、`untracked-target` 和 `modified-target`。自动 PR 仍需通过 `Quality gate` 和 `main` Ruleset。

--- a/scripts/tests/markdown-adapter.test.ts
+++ b/scripts/tests/markdown-adapter.test.ts
@@ -134,6 +134,15 @@ Body text.
     "image-alt",
   );
   assert.equal(
+    prepared.plan.units.find((unit) => unit.text === "Body text.")?.context.fragmented,
+    false,
+  );
+  assert.ok(
+    prepared.plan.units
+      .filter((unit) => ["OpenAI docs", "and", "A chart"].includes(unit.text))
+      .every((unit) => unit.context.fragmented),
+  );
+  assert.equal(
     prepared.plan.units.find((unit) => unit.text === "OpenAI docs")?.batchKey,
     prepared.plan.units.find((unit) => unit.text === "and")?.batchKey,
   );
@@ -191,6 +200,7 @@ test("generated multiline navigation cards translate labels and descriptions", a
   assert.ok(
     prepared.plan.units.every((unit) => unit.context.kind === "link-label"),
   );
+  assert.ok(prepared.plan.units.every((unit) => unit.context.fragmented));
   const rendered = await markdownDocumentAdapter.render(
     prepared.formatState,
     result(

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -424,7 +424,7 @@ test("quality policy preserves glossary terms and placeholders", async () => {
   );
 });
 
-test("quality policy does not match terms inside product names or longer words", async () => {
+test("quality policy handles product names, longer words, and Markdown fragments", async () => {
   const policy = createTranslationQualityPolicy({
     preserve: ["Agents SDK"],
     schemaVersion: 1,
@@ -436,9 +436,13 @@ test("quality policy does not match terms inside product names or longer words",
       workflow: "工作流",
     },
   });
-  const input = (text: string, translatedText: string) => ({
+  const input = (
+    text: string,
+    translatedText: string,
+    fragmented = false,
+  ) => ({
     item: {
-      context: {} as MarkdownTranslationContext,
+      context: { fragmented } as MarkdownTranslationContext,
       id: "unit",
       text,
     },
@@ -465,6 +469,10 @@ test("quality policy does not match terms inside product names or longer words",
   );
   assert.equal(
     await policy(input("Agentic workflows evolve.", "Agentic workflows 持续演进。")),
+    undefined,
+  );
+  assert.equal(
+    await policy(input("Agents like", "诸如", true)),
     undefined,
   );
   assert.equal(

--- a/scripts/translation/markdown-adapter.ts
+++ b/scripts/translation/markdown-adapter.ts
@@ -43,6 +43,7 @@ export interface MarkdownDocumentInput {
 export interface MarkdownTranslationContext {
   block: MarkdownBlockKind;
   end: number;
+  fragmented: boolean;
   kind: MarkdownUnitKind;
   policyVersion: typeof MARKDOWN_ADAPTER_POLICY_VERSION;
   start: number;
@@ -52,6 +53,11 @@ export interface MarkdownSourceRange extends MarkdownTranslationContext {
   id: string;
   sourceText: string;
 }
+
+type PendingMarkdownSourceRange = Omit<
+  MarkdownSourceRange,
+  "fragmented" | "id"
+> & { groupKey: string };
 
 export interface MarkdownFormatState {
   documentId: string;
@@ -154,6 +160,19 @@ function blockKind(ancestors: readonly MarkdownNode[]): MarkdownBlockKind {
   if (ancestors.some((node) => node.type === "listItem")) return "list";
   if (ancestors.some((node) => node.type === "blockquote")) return "quote";
   return "body";
+}
+
+const TRANSLATION_GROUP_NODES = new Set(["heading", "paragraph", "tableCell"]);
+
+function translationGroupKey(
+  node: MarkdownNode,
+  ancestors: readonly MarkdownNode[],
+): string {
+  const group = [...ancestors, node]
+    .reverse()
+    .find((candidate) => TRANSLATION_GROUP_NODES.has(candidate.type));
+  const range = nodeOffsets(group ?? node);
+  return `${range.start}:${range.end}`;
 }
 
 function enclosingLink(
@@ -291,8 +310,8 @@ function textNodeRanges(
 
 function generatedCardTextRanges(
   source: string,
-): Array<{ end: number; start: number }> {
-  const ranges: Array<{ end: number; start: number }> = [];
+): Array<{ end: number; groupKey: string; start: number }> {
+  const ranges: Array<{ end: number; groupKey: string; start: number }> = [];
   GENERATED_CARD_PATTERN.lastIndex = 0;
   for (const match of source.matchAll(GENERATED_CARD_PATTERN)) {
     const matchStart = match.index ?? 0;
@@ -302,10 +321,16 @@ function generatedCardTextRanges(
     const labelOffset = match[0].indexOf(label);
     const descriptionOffset = match[0].lastIndexOf(description);
     if (labelOffset < 0 || descriptionOffset < 0) continue;
+    const groupKey = `${matchStart}:${matchStart + match[0].length}`;
     ranges.push(
-      { end: matchStart + labelOffset + label.length, start: matchStart + labelOffset },
+      {
+        end: matchStart + labelOffset + label.length,
+        groupKey,
+        start: matchStart + labelOffset,
+      },
       {
         end: matchStart + descriptionOffset + description.length,
+        groupKey,
         start: matchStart + descriptionOffset,
       },
     );
@@ -336,10 +361,11 @@ function imageAltRange(node: MarkdownNode, source: string): { end: number; start
 
 function collectRanges(root: MarkdownNode, source: string): MarkdownSourceRange[] {
   const generatedCardRanges = generatedCardTextRanges(source);
-  const pending: Array<Omit<MarkdownSourceRange, "id">> = generatedCardRanges.map(
-    (range) => ({
+  const pending: PendingMarkdownSourceRange[] = generatedCardRanges.map(
+    ({ groupKey, ...range }) => ({
       block: "body",
       end: range.end,
+      groupKey,
       kind: "link-label",
       policyVersion: MARKDOWN_ADAPTER_POLICY_VERSION,
       sourceText: source.slice(range.start, range.end),
@@ -356,10 +382,12 @@ function collectRanges(root: MarkdownNode, source: string): MarkdownSourceRange[
     const contextBlock = blockKind(ancestors);
     if (node.type === "text" && !isAutolinkText(node, ancestors)) {
       const kind: MarkdownUnitKind = enclosingLink(ancestors) ? "link-label" : "text";
+      const groupKey = translationGroupKey(node, ancestors);
       for (const range of textNodeRanges(source, node, sourceProtectedRanges)) {
         pending.push({
           block: contextBlock,
           end: range.end,
+          groupKey,
           kind,
           policyVersion: MARKDOWN_ADAPTER_POLICY_VERSION,
           sourceText: source.slice(range.start, range.end),
@@ -372,6 +400,7 @@ function collectRanges(root: MarkdownNode, source: string): MarkdownSourceRange[
         pending.push({
           block: contextBlock,
           end: range.end,
+          groupKey: translationGroupKey(node, ancestors),
           kind: "image-alt",
           policyVersion: MARKDOWN_ADAPTER_POLICY_VERSION,
           sourceText: source.slice(range.start, range.end),
@@ -385,8 +414,13 @@ function collectRanges(root: MarkdownNode, source: string): MarkdownSourceRange[
 
   visit(root, []);
   pending.sort((left, right) => left.start - right.start || left.end - right.end);
-  return pending.map((range, index) => ({
+  const groupSizes = new Map<string, number>();
+  for (const range of pending) {
+    groupSizes.set(range.groupKey, (groupSizes.get(range.groupKey) ?? 0) + 1);
+  }
+  return pending.map(({ groupKey, ...range }, index) => ({
     ...range,
+    fragmented: (groupSizes.get(groupKey) ?? 0) > 1,
     id: `markdown-${index + 1}-${range.start}-${range.end}`,
   }));
 }
@@ -467,6 +501,7 @@ function assertValidState(state: MarkdownFormatState): void {
       range.end <= range.start ||
       range.end > state.source.length ||
       state.source.slice(range.start, range.end) !== range.sourceText ||
+      typeof range.fragmented !== "boolean" ||
       range.policyVersion !== MARKDOWN_ADAPTER_POLICY_VERSION
     ) {
       throw new Error(`Markdown 翻译区间无效：${range.id}`);

--- a/scripts/translation/planner.ts
+++ b/scripts/translation/planner.ts
@@ -19,7 +19,7 @@ import type {
 } from "./types.ts";
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
-export const MARKDOWN_ADAPTER_POLICY_VERSION = "markdown-source-ranges-v3";
+export const MARKDOWN_ADAPTER_POLICY_VERSION = "markdown-source-ranges-v4";
 
 function sha256(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");

--- a/scripts/translation/runner.ts
+++ b/scripts/translation/runner.ts
@@ -364,20 +364,22 @@ export function createTranslationQualityPolicy(
         };
       }
     }
-    const terminologySource = withoutPreservedTerms(
-      item.text,
-      glossary.preserve,
-    );
-    for (const [source, target] of Object.entries(glossary.terms)) {
-      if (
-        containsCompleteTerm(terminologySource, source) &&
-        !translatedText.includes(target)
-      ) {
-        return {
-          issueCode: "translation.term_missing",
-          message: `术语 ${source} 必须翻译为 ${target}。`,
-          retryInstruction: `使用指定术语：${source} → ${target}。`,
-        };
+    if (!item.context.fragmented) {
+      const terminologySource = withoutPreservedTerms(
+        item.text,
+        glossary.preserve,
+      );
+      for (const [source, target] of Object.entries(glossary.terms)) {
+        if (
+          containsCompleteTerm(terminologySource, source) &&
+          !translatedText.includes(target)
+        ) {
+          return {
+            issueCode: "translation.term_missing",
+            message: `术语 ${source} 必须翻译为 ${target}。`,
+            retryInstruction: `使用指定术语：${source} → ${target}。`,
+          };
+        }
       }
     }
     const sourceTokens = sortedTokens(item.text);


### PR DESCRIPTION
## 问题

[Translate Chinese docs #6](https://github.com/jiahim/OpenAI-API-Chinese/actions/runs/32936845195) 在翻译 `docs/en/api/docs/guides/background.md` 时失败。原文 `Agents like [Codex] ...` 被 Markdown 适配器拆成多个翻译单元；中文译法可将“智能体”移动到链接后的相邻片段，但质量门错误地要求 `Agents like` 这个片段自身必须包含“智能体”，因此所有重试都被拒绝。

## 修复

- 为同一 Markdown 标题、段落或表格单元中的翻译片段标记 `fragmented`
- 完整语义块继续严格检查指定术语
- 被链接、图片、代码或换行拆分的语义块仍将术语表随批次发送给模型，但不再做不成立的逐片段术语断言
- 将 Markdown 适配器策略版本升级为 v4，避免复用旧 checkpoint
- 增加远端失败场景与普通未拆分术语场景的回归测试

## 验证

- `pnpm typecheck`
- `pnpm test`（66/66）
- `pnpm translate:check`（完整性通过）