### PR TITLE
[AI] fix: 修复 Vercel 产物目录配置

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -147,7 +147,7 @@ pnpm test
 
 ### 2.8 Vercel 静态站与后续抽取
 
-- 首个站点当前放在 `apps/web`，使用 Next.js `output: export`，Vercel Root Directory 为 `apps/web`，输出目录为 `out`。
+- 首个站点当前放在 `apps/web`，使用 Next.js `output: export`，本地静态产物位于 `apps/web/out`；Vercel Root Directory 为 `apps/web`，Output Directory 必须保持未覆盖并交由 Next.js Preset 自动检测。
 - `Quality gate` 会独立安装 Web 子项目依赖，并运行内容生成、typecheck、lint、链接测试和完整静态构建。
 - 构建器读取 source/translation manifest，并严格按两份官方 `llms.txt` 的分组和顺序生成导航；421 个 active 页面必须全部且仅出现一次。
 - 421 篇英文 Markdown 全部生成静态路径；414 篇直接渲染正文，7 篇超过 1 MB 的事件/资源总表先保留轻量说明页，后续按结构拆分。中文译文沿用相同路径；中文尚未生成时仍保留结构化状态页，并优先链接本站英文原文。

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -44,10 +44,12 @@ pnpm build
 | Framework Preset | Next.js |
 | Install Command | `pnpm install` |
 | Build Command | `pnpm build` |
-| Output Directory | `out` |
+| Output Directory | 不覆盖，由 Next.js Preset 自动检测 |
 | Node.js | 22.13 或更高 |
 
 在 Root Directory 设置中启用 **Include source files outside of the Root Directory in the Build Step**。这是必须项：Vercel 默认不允许项目读取 Root Directory 外的文件，而本项目的 Markdown 位于仓库根部 `docs/`。
+
+不要在 Vercel Dashboard 或 `vercel.json` 中把 Output Directory 覆盖为 `out`。`output: "export"` 仍会在本地生成 `apps/web/out`，但 Vercel 的 Next.js 构建器需要自行接管框架产物；强制覆盖会使其在 `out` 中错误查找 `routes-manifest.json`。
 
 设置环境变量：
 

--- a/apps/web/tests/links.test.ts
+++ b/apps/web/tests/links.test.ts
@@ -116,4 +116,13 @@ describe("document link rewriting", () => {
     const expectedSchedule = `每天 ${String(expectedHour).padStart(2, "0")}:${cron[1].padStart(2, "0")} · 北京时间`;
     assert.equal(sourceCheckSchedule, expectedSchedule);
   });
+
+  it("leaves Vercel output detection to the Next.js preset", async () => {
+    const vercelConfig = JSON.parse(
+      await readFile(resolve(process.cwd(), "vercel.json"), "utf8"),
+    ) as Record<string, unknown>;
+    assert.equal(vercelConfig.framework, "nextjs");
+    assert.equal(vercelConfig.buildCommand, "pnpm build");
+    assert.equal("outputDirectory" in vercelConfig, false);
+  });
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "pnpm build",
-  "outputDirectory": "out"
+  "buildCommand": "pnpm build"
 }

--- a/docs/static-site-architecture.md
+++ b/docs/static-site-architecture.md
@@ -242,10 +242,12 @@ Vercel 项目设置：
 | Framework Preset | Next.js |
 | Install Command | `pnpm install` |
 | Build Command | `pnpm build` |
-| Output Directory | `out` |
+| Output Directory | 不覆盖，由 Next.js Preset 自动检测 |
 | 环境变量 | `NEXT_PUBLIC_SITE_ORIGIN=https://正式域名` |
 
 Root Directory 设置必须启用 **Include source files outside of the Root Directory in the Build Step**；Vercel 默认禁止项目访问 Root Directory 外的文件，而当前内容位于仓库根部 `docs/`。
+
+Vercel 的 Output Directory 必须保持未覆盖。虽然 Next.js `output: "export"` 会为通用静态托管生成本地 `apps/web/out`，Vercel 的 Next.js 构建器仍需按框架约定收集产物；把 Output Directory 强制设为 `out` 会导致 `routes-manifest.json` 查找失败。
 
 部署原则：
 


### PR DESCRIPTION
## 问题

Vercel 已成功完成 Next.js 编译并生成 851 个静态页面，但 `vercel.json` 将 Output Directory 强制覆盖为 `out`，导致 Vercel 的 Next.js 构建器随后在 `out` 中查找 `routes-manifest.json` 并失败。

## 修复

- 从 `vercel.json` 移除 `outputDirectory: "out"`，交由 Next.js Preset 自动检测框架产物
- 修正 Vercel 部署文档，明确 Dashboard 中也不能覆盖 Output Directory
- 增加回归测试，拒绝重新引入 `outputDirectory`

## 验证

- `pnpm web:typecheck`
- `pnpm web:lint`
- `pnpm web:test`（7/7）
- `pnpm web:build`（851 个静态页面）

## 部署操作

合并后，在 Vercel Project Settings → Build & Deployment 中清空 Output Directory，并关闭 Override，然后重新部署。