### PR TITLE
[AI] fix: 提升保留词翻译稳定性

### DIFF
--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -73,7 +73,7 @@ render 拒绝缺失或多余单元、空文本、换行/控制字符、被篡改
 
 - 文档级选择由源 SHA 和 `policySha256` 决定。
 - 自动队列先按 `stale-source`、`stale-policy`、`missing-target`、`pending` 维护状态排序；同一状态内按版本化的核心文档清单排序，未列入清单的页面按稳定路径回退。选择优先级不改变译文内容，因此不参与 `policySha256`。
-- 单篇文档内部使用 Easy Translate checkpoint；批次对格式、质量和可重试 Provider 错误做有限指数退避，批次耗尽后页面可从 checkpoint 额外恢复一次。认证、配置、路径和完整性错误不重试。只有整篇 render 和质量检查成功后才原子更新译文与 manifest。
+- 单篇文档内部使用 Easy Translate checkpoint；批次对格式、质量和可重试 Provider 错误做有限指数退避。质量错误会携带定向修正提示重试，但同一单元、规则和消息再次失败时立即停止；批次耗尽后，只有格式响应错误和可重试 Provider 错误可以从 checkpoint 做一次页面级恢复，质量错误不再整页重试。认证、配置、路径和完整性错误不重试。只有整篇 render 和质量检查成功后才原子更新译文与 manifest。
 - 批量任务默认低并发，先支持 `--section`、`--match` 和 `--limit`，再开放全量运行。
 - 质量检查至少覆盖：Markdown 可重新解析、保护内容一致、无空译文、链接目标一致、代码块一致、manifest/文件 SHA 一致。
 - 机器译文以 PR 形式进入 `main`；人工校对只提升 `reviewStatus`，英文或策略变化后仍会重新标记 stale。
@@ -81,7 +81,7 @@ render 拒绝缺失或多余单元、空文本、换行/控制字符、被篡改
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 
-真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配替换为批次内唯一占位符，响应后再逐字恢复；指定译法只检查完整单词或短语，并排除已整体保留的产品名。质量策略会独立复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制指定译法，因为中文语序可能把术语移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
+真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配包裹为批次内唯一的成对保护标记，标记内部保留可见原词；响应后无论模型复制标记、只去掉标记外壳，还是改写成对标记内的内容，都恢复为原词，残留或被破坏的标记会被质量错误拒绝。指定译法只检查完整单词或短语，并排除已整体保留的产品名。质量策略会独立复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制指定译法，因为中文语序可能把术语移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
 
 ## 分阶段交付
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,6 +143,6 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多十篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
-生产翻译采用分层恢复：术语表的 `preserve` 项在发送前替换为唯一占位符，模型返回后再逐字恢复；指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。当一个 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，术语表仍随完整批次发送给模型，但质量门不再要求每个片段各自包含目标术语，避免中文调整语序后被误判。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间。批次仍失败时，整页等待 10–12 秒后额外恢复 1 次，已完成批次从 Git 忽略的 checkpoint 继续，不重复调用。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
+生产翻译采用分层恢复：术语表的 `preserve` 项在发送前按最长匹配包裹为唯一的成对保护标记，标记内保留可见原词；模型复制标记、去掉外壳或改写成对标记内文本时，返回后都会恢复原词，任何保护标记残留都会被拒绝。指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。当一个 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，术语表仍随完整批次发送给模型，但质量门不再要求每个片段各自包含目标术语，避免中文调整语序后被误判。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间；同一质量错误再次出现时提前终止。批次仍失败时，只有格式响应错误和可重试 Provider 错误会在等待 10–12 秒后从 checkpoint 做一次页面恢复，质量错误不再整页重试。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
 
 CI 使用完全离线的 `translate:check` 验证 translation manifest；它允许尚未翻译或因英文更新而 stale 的页面存在，但拒绝 `missing-target`、`untracked-target` 和 `modified-target`。自动 PR 仍需通过 `Quality gate` 和 `main` Ruleset。

--- a/scripts/tests/translation-planner.test.ts
+++ b/scripts/tests/translation-planner.test.ts
@@ -14,6 +14,12 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  TranslationErrorCode,
+  TranslationProviderError,
+  TranslationResponseError,
+} from "@easy-translate/core";
+
+import {
   buildTranslationStatusReport,
   classifyTranslationPage,
   mirroredTranslationPath,
@@ -27,7 +33,9 @@ import type {
 import {
   assertTranslationIntegrity,
   automaticTranslationCandidates,
+  createProductionBatchRetryPolicy,
   parseCliOptions,
+  shouldRetryProductionPage,
 } from "../translate-docs.ts";
 import { parseTranslationPriorityConfig } from "../translation/priority.ts";
 
@@ -37,6 +45,48 @@ const TARGET_PATH = "docs/zh/api/docs/quickstart.md";
 const SOURCE_CONTENT = "# Quickstart\n";
 const SOURCE_HASH = sha256(SOURCE_CONTENT);
 const TARGET_CONTENT = "# 快速开始\n";
+
+test("production retries one targeted correction but stops repeated quality failures", () => {
+  const quality = new TranslationResponseError(
+    TranslationErrorCode.ResponseQualityRejected,
+    "必须保留术语：API",
+    {
+      details: {
+        issueCode: "translation.preserve_missing",
+        unitId: "markdown-54-4751-4880",
+      },
+    },
+  );
+  const otherQuality = new TranslationResponseError(
+    TranslationErrorCode.ResponseQualityRejected,
+    "必须保留术语：SDK",
+    {
+      details: {
+        issueCode: "translation.preserve_missing",
+        unitId: "markdown-55-4881-4900",
+      },
+    },
+  );
+  const malformed = new TranslationResponseError(
+    TranslationErrorCode.ResponseInvalidContainer,
+    "invalid JSON",
+  );
+  const network = new TranslationProviderError(
+    TranslationErrorCode.ProviderNetwork,
+    "network failure",
+    { retryable: true },
+  );
+  const policy = createProductionBatchRetryPolicy();
+
+  assert.equal(policy.shouldRetry?.(quality, 0), true);
+  assert.equal(policy.shouldRetry?.(quality, 1), false);
+  assert.equal(policy.shouldRetry?.(otherQuality, 1), true);
+  assert.equal(policy.shouldRetry?.(malformed, 0), true);
+  assert.equal(policy.shouldRetry?.(network, 0), true);
+  assert.equal(shouldRetryProductionPage(quality), false);
+  assert.equal(shouldRetryProductionPage(malformed), true);
+  assert.equal(shouldRetryProductionPage(network), true);
+});
 
 function sha256(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");

--- a/scripts/tests/translation-provider.test.ts
+++ b/scripts/tests/translation-provider.test.ts
@@ -28,9 +28,11 @@ test("configured DeepSeek provider requires its key without exposing credentials
 
 test("preserve-term provider masks longest matches and restores exact terms", async () => {
   let observedText = "";
+  let observedInstructions = "";
   const provider = defineProvider({
     async translateBatch(request) {
       observedText = request.items[0]?.text ?? "";
+      observedInstructions = request.instructions ?? "";
       return request.items.map((item) => ({
         id: item.id,
         text: item.text.replace(" and ", " 与 "),
@@ -46,13 +48,68 @@ test("preserve-term provider masks longest matches and restores exact terms", as
       {
         context: {},
         id: "unit",
-        text: "Responses API and API",
+        text: "Responses API and API&#x20;",
       },
+    ],
+    instructions: "Translate accurately.",
+    targetLanguage: "zh-CN",
+  });
+
+  assert.equal(
+    observedText,
+    "{{ET_KEEP_0_0_0_START}}Responses API{{ET_KEEP_0_0_0_END}} and " +
+      "{{ET_KEEP_0_0_1_START}}API{{ET_KEEP_0_0_1_END}}&#x20;",
+  );
+  assert.match(observedInstructions, /Copy every marker pair/u);
+  assert.equal(output[0]?.text, "Responses API 与 API&#x20;");
+});
+
+test("preserve-term provider recovers when markers or protected text change", async () => {
+  const markerPattern = /\{\{ET_KEEP_\d+_\d+_\d+_(?:START|END)\}\}/gu;
+  const pairedContentPattern =
+    /(\{\{ET_KEEP_\d+_\d+_\d+_START\}\})[^{}]*(\{\{ET_KEEP_\d+_\d+_\d+_END\}\})/gu;
+  const provider = defineProvider({
+    async translateBatch(request) {
+      return request.items.map((item) => ({
+        id: item.id,
+        text:
+          item.id === "markers-removed"
+            ? item.text.replace(markerPattern, "")
+            : item.text.replace(pairedContentPattern, "$1接口$2"),
+      }));
+    },
+  });
+  const protectedProvider = createPreserveTermsProvider(provider, ["API"]);
+  const output = await protectedProvider.translateBatch({
+    items: [
+      { context: {}, id: "markers-removed", text: "Realtime API rejects it." },
+      { context: {}, id: "content-changed", text: "Realtime API rejects it." },
     ],
     targetLanguage: "zh-CN",
   });
 
-  assert.equal(observedText.includes("API"), false);
-  assert.equal(observedText.match(/\{\{ET_KEEP_/gu)?.length, 2);
-  assert.equal(output[0]?.text, "Responses API 与 API");
+  assert.deepEqual(
+    output.map((item) => item.text),
+    ["Realtime API rejects it.", "Realtime API rejects it."],
+  );
+});
+
+test("preserve-term provider rejects marker residue instead of leaking it", async () => {
+  const provider = defineProvider({
+    async translateBatch(request) {
+      return request.items.map((item) => ({
+        id: item.id,
+        text: item.text.replace("_START}}", "_START_CHANGED}}"),
+      }));
+    },
+  });
+  const protectedProvider = createPreserveTermsProvider(provider, ["API"]);
+
+  await assert.rejects(
+    protectedProvider.translateBatch({
+      items: [{ context: {}, id: "unit", text: "Realtime API rejects it." }],
+      targetLanguage: "zh-CN",
+    }),
+    /保留词保护标记被模型改写/u,
+  );
 });

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -6,6 +6,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   createEchoProvider,
   isTranslationCoreError,
+  TranslationProviderError,
+  TranslationResponseError,
   type RetryOperationOptions,
   type TranslationProvider,
   type TranslationRetryEvent,
@@ -68,6 +70,7 @@ const TRANSLATION_PAGE_RETRY_POLICY = {
   jitterMs: 2_000,
   maxDelayMs: 15_000,
   maxRetries: 1,
+  shouldRetry: shouldRetryProductionPage,
 } satisfies TranslationRetryPolicy;
 const TRANSLATABLE_STATES = new Set<TranslationPageState>([
   "missing-target",
@@ -94,6 +97,37 @@ function translationUnitId(error: unknown): string | undefined {
   if (!isTranslationCoreError(error)) return undefined;
   const unitId = error.details.unitId;
   return typeof unitId === "string" && unitId ? unitId : undefined;
+}
+
+function qualityFailureFingerprint(error: TranslationResponseError): string {
+  const unitId = error.details.unitId;
+  const issueCode = error.details.issueCode;
+  return JSON.stringify([
+    typeof unitId === "string" ? unitId : "",
+    typeof issueCode === "string" ? issueCode : "",
+    error.message,
+  ]);
+}
+
+export function createProductionBatchRetryPolicy(): TranslationRetryPolicy {
+  const seenQualityFailures = new Set<string>();
+  return {
+    ...TRANSLATION_BATCH_RETRY_POLICY,
+    shouldRetry(error) {
+      if (error instanceof TranslationProviderError) return error.retryable;
+      if (!(error instanceof TranslationResponseError)) return false;
+      if (error.reason !== "quality") return true;
+      const fingerprint = qualityFailureFingerprint(error);
+      if (seenQualityFailures.has(fingerprint)) return false;
+      seenQualityFailures.add(fingerprint);
+      return true;
+    },
+  };
+}
+
+export function shouldRetryProductionPage(error: unknown): boolean {
+  if (error instanceof TranslationProviderError) return error.retryable;
+  return error instanceof TranslationResponseError && error.reason !== "quality";
 }
 
 function logRetry(
@@ -129,6 +163,7 @@ async function runProductionTranslationPage(
   provider: TranslationProvider<MarkdownTranslationContext>,
   commit: boolean,
 ) {
+  const batchRetry = createProductionBatchRetryPolicy();
   const pageRetry: RetryOperationOptions = {
     ...TRANSLATION_PAGE_RETRY_POLICY,
     onRetry: (event) => logRetry("page", page, event),
@@ -139,7 +174,7 @@ async function runProductionTranslationPage(
       onRetry: (event) => logRetry("batch", page, event),
       pageRetry,
       provider,
-      retry: TRANSLATION_BATCH_RETRY_POLICY,
+      retry: batchRetry,
     });
   } catch (error) {
     throw translationFailure(page, error);

--- a/scripts/translation/provider.ts
+++ b/scripts/translation/provider.ts
@@ -1,15 +1,28 @@
 import { createDeepSeekProvider } from "@easy-translate/providers";
-import type {
-  TranslationBatchRequest,
-  TranslationProvider,
+import {
+  TranslationErrorCode,
+  TranslationResponseError,
+  type TranslationBatchRequest,
+  type TranslationProvider,
 } from "@easy-translate/core";
 
 import type { MarkdownTranslationContext } from "./markdown-adapter.ts";
 import type { TranslationProviderProfile } from "./types.ts";
 
 interface PreserveReplacement {
+  closeToken: string;
+  openToken: string;
   term: string;
-  token: string;
+}
+
+const PRESERVE_MARKER_INSTRUCTION =
+  "Paired {{ET_KEEP_*_START}} and {{ET_KEEP_*_END}} markers wrap protected source text. " +
+  "Copy every marker pair and its enclosed text verbatim into the matching translation item; " +
+  "never translate, omit, or move a protected span.";
+const PRESERVE_MARKER_RESIDUE_PATTERN = /ET_KEEP_\d+_\d+_\d+/u;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function protectPreserveTerms(
@@ -18,20 +31,61 @@ function protectPreserveTerms(
   requestIndex: number,
   itemIndex: number,
 ): { replacements: PreserveReplacement[]; text: string } {
-  let protectedText = text;
   const replacements: PreserveReplacement[] = [];
-  for (const [termIndex, term] of terms.entries()) {
-    if (!protectedText.includes(term)) continue;
-    let tokenIndex = termIndex;
-    let token = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}}}`;
-    while (protectedText.includes(token)) {
-      tokenIndex += terms.length;
-      token = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}}}`;
+  const pattern = new RegExp(terms.map(escapeRegExp).join("|"), "gu");
+  let nextTokenIndex = 0;
+  const protectedText = text.replace(pattern, (term) => {
+    let tokenIndex = nextTokenIndex;
+    let openToken = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}_START}}`;
+    let closeToken = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}_END}}`;
+    while (text.includes(openToken) || text.includes(closeToken)) {
+      tokenIndex += 1;
+      openToken = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}_START}}`;
+      closeToken = `{{ET_KEEP_${requestIndex}_${itemIndex}_${tokenIndex}_END}}`;
     }
-    protectedText = protectedText.split(term).join(token);
-    replacements.push({ term, token });
-  }
+    nextTokenIndex = tokenIndex + 1;
+    replacements.push({ closeToken, openToken, term });
+    return `${openToken}${term}${closeToken}`;
+  });
   return { replacements, text: protectedText };
+}
+
+function restorePreserveReplacement(
+  text: string,
+  replacement: PreserveReplacement,
+): string {
+  let restored = text;
+  const maximumProtectedLength = Math.max(
+    replacement.term.length * 4,
+    replacement.term.length + 32,
+  );
+  while (true) {
+    const openIndex = restored.indexOf(replacement.openToken);
+    if (openIndex < 0) break;
+    const contentStart = openIndex + replacement.openToken.length;
+    const closeIndex = restored.indexOf(replacement.closeToken, contentStart);
+    if (closeIndex < 0) {
+      restored =
+        restored.slice(0, openIndex) +
+        restored.slice(openIndex + replacement.openToken.length);
+      continue;
+    }
+    const protectedContent = restored.slice(contentStart, closeIndex);
+    if (
+      protectedContent.length <= maximumProtectedLength &&
+      !protectedContent.includes("{{ET_KEEP_")
+    ) {
+      restored =
+        restored.slice(0, openIndex) +
+        replacement.term +
+        restored.slice(closeIndex + replacement.closeToken.length);
+      continue;
+    }
+    restored =
+      restored.slice(0, openIndex) +
+      restored.slice(openIndex + replacement.openToken.length);
+  }
+  return restored.split(replacement.closeToken).join("");
 }
 
 function restorePreserveTerms(
@@ -40,7 +94,7 @@ function restorePreserveTerms(
 ): string {
   let restored = text;
   for (const replacement of replacements) {
-    restored = restored.split(replacement.token).join(replacement.term);
+    restored = restorePreserveReplacement(restored, replacement);
   }
   return restored;
 }
@@ -71,22 +125,45 @@ export function createPreserveTermsProvider<TContext>(
         replacementsById.set(item.id, protectedItem.replacements);
         return { ...item, text: protectedItem.text };
       });
+      const hasReplacements = [...replacementsById.values()].some(
+        (replacements) => replacements.length > 0,
+      );
       const protectedRequest: TranslationBatchRequest<TContext> = {
         ...request,
         items,
+        ...(hasReplacements
+          ? {
+              instructions: [request.instructions, PRESERVE_MARKER_INSTRUCTION]
+                .filter(Boolean)
+                .join("\n"),
+            }
+          : {}),
       };
       const output = await provider.translateBatch(
         protectedRequest,
         signal,
         onActivity,
       );
-      return output.map((item) => ({
-        ...item,
-        text: restorePreserveTerms(
+      return output.map((item) => {
+        const text = restorePreserveTerms(
           item.text,
           replacementsById.get(item.id) ?? [],
-        ),
-      }));
+        );
+        if (PRESERVE_MARKER_RESIDUE_PATTERN.test(text)) {
+          throw new TranslationResponseError(
+            TranslationErrorCode.ResponseQualityRejected,
+            "保留词保护标记被模型改写。",
+            {
+              details: {
+                issueCode: "translation.preserve_marker_changed",
+                unitId: item.id,
+              },
+              retryInstruction: PRESERVE_MARKER_INSTRUCTION,
+            },
+          );
+        }
+        return { ...item, text };
+      });
     },
   };
 }


### PR DESCRIPTION
## 问题

生产翻译在 `docs/en/api/docs/guides/realtime-transcription.md` 的 `markdown-54-4751-4880` 连续失败：原文包含 `Realtime API`，但旧实现会把 `API` 完全替换成不透明 `{{ET_KEEP_*}}` 占位符。模型一旦遗漏或改写该占位符，恢复阶段无法找回 `API`，后续重试提示又与模型实际看到的文本不一致。

## 修复

- 将保留词改为“成对保护标记 + 标记内可见原词”
- 按最长匹配一次性生成保护区间，避免 `Responses API` 被内部的 `API` 二次匹配
- 模型复制标记、移除标记外壳或改写成对标记内文本时，均恢复为精确原词
- 检测并拒绝任何被破坏的保护标记，防止标记泄漏到中文文档
- 同一 `unitId + issueCode + message` 质量错误只进行一次定向修正
- 质量错误不再触发整页重试；格式响应和可重试 Provider 错误仍保留页面级恢复

## 验证

- `pnpm typecheck`
- `pnpm test`（69/69）
- `pnpm docs:status`
- `pnpm translate:check`（10 current、411 pending，完整性通过）
- 覆盖 `API&#x20;`、最长匹配、标记外壳移除、标记内改写和标记残留回归场景

本地 web 依赖安装在最后一个上游大包下载时超时；web 文件未修改，完整 web 检查由本 PR 的 GitHub CI 验证。