### PR TITLE
[AI] feat: 改进文档站导航、更新批次与翻译审核

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -71,6 +71,13 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+          node scripts/sync-pr-summary.ts \
+            --base-ref "origin/$BASE_BRANCH" \
+            --output "$RUNNER_TEMP/sync-pr-body.md" \
+            --release-dir "docs/updates"
+          git add docs/updates
+          git commit --amend --no-edit
+
           if git show-ref --verify --quiet "refs/remotes/origin/$SYNC_BRANCH"; then
             if git diff --quiet "refs/remotes/origin/$SYNC_BRANCH" HEAD --; then
               echo "Automation branch is already current."

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -161,6 +161,7 @@ jobs:
               "",
               "- 检查中文准确性、术语和可读性。",
               "- 不要直接修改代码、URL、模型 ID 或 Markdown 结构。",
+              "- 固定译法写入术语表；单页上下文或官方原文勘误写入 `scripts/translation/review-notes.zh-CN.json`。",
               "- 人工润色后运行 `pnpm translate:review -- --match <精确路径> --limit 1`。",
               "- 合入仍须通过 `Quality gate` 和 `main` Ruleset。",
             ].join("\n");

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行�
 
 `translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端按优先级选择最多十篇受预算约束的页面；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。
 
+人工校对中可复用的固定译法应进入术语表，通用表达要求应进入翻译提示词；只适用于单篇文档的上下文、歧义或官方原文勘误记录在 `scripts/translation/review-notes.zh-CN.json`。页面级备注会自动加入该页翻译请求和策略 SHA，仅让对应页面进入 `stale-policy`，不会触发全站重翻。
+
 ## 静态双语文档站
 
 当前仓库同时维护首个可用站点 [`apps/web`](apps/web)。它在构建期读取 source/translation manifest 和磁盘 Markdown，按官方 `llms.txt` 的分组与顺序生成完整导航：421 篇英文源页面都有稳定静态路由，其中 414 篇直接渲染正文；7 篇超过 1 MB 的事件/资源总表暂时生成轻量说明页，避免单页 HTML 和 Vercel 产物异常膨胀。已有中文译文显示在同路径的 `/zh/` 页面，其余中文路径保留原目录位置并引导到本站英文原文。Markdown 中指向 `developers.openai.com/api/docs` 与 `/api/reference` 的链接会转换为当前语言的本站路由，外部链接保持明确标识。

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -74,9 +74,6 @@ button, input { font: inherit; }
 .sidebar-heading span { font-size: .929rem; font-weight: 800; }
 .sidebar-heading strong { border-radius: 99px; padding: 3px 7px; background: var(--soft); color: var(--muted); font-size: .786rem; }
 .sidebar-groups details { border-top: 1px solid #edf0ee; }
-.sidebar-group-link { display: flex; align-items: center; justify-content: space-between; border-top: 1px solid #edf0ee; padding: 11px 6px 11px 21px; color: #4e5b55; font-size: .857rem; font-weight: 800; }
-.sidebar-group-link small { color: #9aa39e; font-size: .786rem; }
-.sidebar-group-link:hover { color: var(--accent); }
 .sidebar-groups summary {
   display: flex;
   cursor: pointer;
@@ -97,6 +94,7 @@ button, input { font: inherit; }
 .sidebar-links a { display: flex; min-width: 0; align-items: center; gap: 7px; border-radius: 7px; padding: 7px 8px; color: #68746e; font-size: .857rem; line-height: 1.45; }
 .sidebar-links a span { overflow: hidden; text-overflow: ellipsis; }
 .sidebar-links a i { width: 5px; height: 5px; flex: none; border-radius: 50%; background: var(--accent); }
+.sidebar-links a small { margin-left: auto; color: #9aa39e; }
 .sidebar-links a:hover { background: var(--soft); color: var(--ink); }
 .sidebar-links a.active { background: var(--accent-soft); color: var(--accent-dark); font-weight: 700; }
 .sidebar-note { display: flex; margin: 20px 4px 0; border-radius: 10px; padding: 12px; background: var(--soft); flex-direction: column; gap: 5px; }
@@ -113,7 +111,12 @@ h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; le
 .reviewed-badge { flex: none; border-radius: 99px; padding: 6px 9px; background: var(--accent-soft); color: var(--accent); font-size: .786rem; font-weight: 700; }
 .reviewed-badge.machine { background: var(--warm); color: #79692e; }
 .reviewed-badge.source { background: #eef1f7; color: #52627c; }
-.source-notice { display: flex; margin: 30px 0 40px; align-items: center; justify-content: space-between; gap: 20px; border-left: 3px solid var(--accent); padding: 12px 16px; background: var(--soft); color: var(--muted); font-size: .857rem; line-height: 1.6; }
+.document-timestamps { display: flex; margin: 24px 0 0; align-items: center; flex-wrap: wrap; gap: 10px 22px; color: var(--muted); }
+.document-timestamps > div { display: flex; align-items: baseline; gap: 7px; }
+.document-timestamps dt { color: #87918c; font-size: .786rem; font-weight: 700; }
+.document-timestamps dd { margin: 0; color: #435149; font-size: .857rem; font-weight: 700; }
+.document-timestamps > span { color: #9aa39e; font-size: .714rem; }
+.source-notice { display: flex; margin: 18px 0 40px; align-items: center; justify-content: space-between; gap: 20px; border-left: 3px solid var(--accent); padding: 12px 16px; background: var(--soft); color: var(--muted); font-size: .857rem; line-height: 1.6; }
 .source-notice a { flex: none; color: var(--accent-dark); font-weight: 800; }
 .toc { display: flex; max-height: calc(100vh - 120px); overflow-y: auto; border-left: 1px solid var(--line); padding-left: 18px; flex-direction: column; gap: 10px; }
 .toc p { margin: 0 0 4px; color: #87918c; font-size: .786rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
@@ -183,6 +186,14 @@ h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; le
 .home-shell { min-height: 100vh; background: linear-gradient(180deg, #f2f8f5 0, #fff 570px); }
 .home-header { display: flex; min-height: 72px; align-items: center; justify-content: space-between; border-bottom: 1px solid rgba(225,231,227,.8); padding: 0 max(24px, calc((100vw - 1160px) / 2)); }
 .home-header nav { display: flex; align-items: center; gap: 8px; }
+.contact-popover { position: relative; align-self: stretch; }
+.contact-trigger { display: inline-flex; height: 100%; cursor: pointer; align-items: center; gap: 7px; border: 0; padding: 0 8px; background: transparent; color: #89938e; font-size: .857rem; font-weight: 700; transition: color 160ms ease; }
+.contact-trigger:hover, .contact-trigger.active { color: var(--ink); }
+.contact-trigger > span { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+.contact-card { position: absolute; z-index: 50; top: 100%; right: 0; width: min(272px, calc(100vw - 40px)); padding-top: 8px; opacity: 0; pointer-events: none; transform: translateY(-4px); transform-origin: top right; transition: opacity 180ms ease, transform 180ms ease; }
+.contact-card.open { opacity: 1; pointer-events: auto; transform: translateY(0); }
+.contact-card > div { overflow: hidden; border: 1px solid rgba(23,33,29,.12); padding: 6px; background: white; box-shadow: 0 18px 50px rgba(23,33,29,.18); }
+.contact-card img { display: block; width: auto; max-width: 100%; height: auto; max-height: calc(100dvh - 80px); margin: 0 auto; object-fit: contain; }
 .repository-link, .official-nav-link { border: 1px solid var(--line); border-radius: 9px; padding: 8px 11px; background: white; color: #52605a; font-size: .929rem; font-weight: 700; }
 .official-nav-link { border-color: #aed2c1; color: var(--accent-dark); }
 .hero { max-width: 1000px; margin: 0 auto; padding: 92px 30px 66px; text-align: center; }
@@ -203,10 +214,11 @@ h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; le
 .official-source { display: flex; width: min(1100px, calc(100% - 64px)); margin: 0 auto 92px; align-items: center; justify-content: space-between; gap: 24px; border: 1px solid #b8d8ca; border-radius: 14px; padding: 15px 18px; background: #f3faf7; box-shadow: 0 12px 32px rgba(18,82,58,.05); }
 .official-source > p { margin: 0; color: #53645c; font-size: 1rem; line-height: 1.65; }
 .official-source > a { flex: none; border-radius: 10px; padding: 12px 16px; background: var(--accent-dark); color: white; font-size: .929rem; font-weight: 800; }
-.structure-section, .translated-section { max-width: 1160px; margin: 0 auto; padding: 0 30px 92px; }
+.structure-section, .updates-section { max-width: 1160px; margin: 0 auto; padding: 0 30px 92px; }
 .collection-heading { display: flex; align-items: end; justify-content: space-between; gap: 24px; border-bottom: 1px solid var(--line); padding-bottom: 20px; }
 .collection-heading h2 { max-width: 700px; margin: 0; font-size: 2rem; letter-spacing: -.035em; }
 .collection-heading > span { color: var(--muted); font-size: .857rem; }
+.collection-heading > a { color: var(--accent); font-size: .857rem; font-weight: 800; }
 .structure-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-top: 20px; }
 .structure-grid > a { border: 1px solid var(--line); border-radius: 16px; padding: 26px; background: white; transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease; }
 .structure-grid > a:hover { border-color: #9ecab7; box-shadow: 0 18px 38px rgba(24,55,42,.08); transform: translateY(-2px); }
@@ -220,12 +232,46 @@ h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; le
 .structure-grid footer { display: flex; margin-top: 24px; align-items: baseline; gap: 5px; border-top: 1px solid var(--line); padding-top: 16px; color: var(--muted); font-size: .857rem; }
 .structure-grid footer strong { color: var(--ink); font-size: 1.286rem; }
 .structure-grid footer span { margin-left: auto; color: var(--accent); font-weight: 800; }
-.translation-list { display: flex; margin-top: 14px; flex-direction: column; }
-.translation-list a { display: grid; align-items: center; grid-template-columns: 110px 1fr auto; gap: 20px; border-bottom: 1px solid var(--line); padding: 16px 4px; }
-.translation-list a > span { color: var(--accent); font-size: .857rem; font-weight: 700; }
-.translation-list strong { font-size: 1rem; }
-.translation-list small { color: var(--muted); font-size: .857rem; }
+.updates-intro { max-width: 680px; margin: 18px 0 0; color: var(--muted); font-size: .929rem; line-height: 1.7; }
+.update-batch-list { display: flex; margin-top: 18px; flex-direction: column; }
+.update-batch-list > a { display: grid; align-items: center; grid-template-columns: minmax(220px, 1fr) auto 100px; gap: 30px; border-bottom: 1px solid var(--line); padding: 18px 4px; transition: padding 160ms ease, background 160ms ease; }
+.update-batch-list > a:first-child { border-top: 1px solid var(--line); }
+.update-batch-list > a:hover { padding-right: 12px; padding-left: 12px; background: var(--soft); }
+.update-batch-list > a > div { display: flex; min-width: 0; flex-direction: column; gap: 5px; }
+.update-batch-list time { color: var(--accent); font-size: .786rem; font-weight: 800; }
+.update-batch-list strong { font-size: 1rem; }
+.update-batch-list dl { display: flex; margin: 0; gap: 8px; }
+.update-batch-list dl > div { display: flex; align-items: center; gap: 5px; border-radius: 99px; padding: 5px 9px; background: var(--soft); font-size: .786rem; }
+.update-batch-list dt { color: var(--muted); }
+.update-batch-list dd { margin: 0; font-weight: 800; }
+.update-batch-list .added dd { color: var(--accent); }
+.update-batch-list .modified dd { color: #916b10; }
+.update-batch-list .removed dd { color: #a14f49; }
+.update-batch-list > a > span { color: var(--accent); font-size: .786rem; font-weight: 800; text-align: right; }
 .home-footer { display: flex; min-height: 72px; align-items: center; justify-content: space-between; border-top: 1px solid var(--line); padding: 0 max(24px, calc((100vw - 1100px) / 2)); color: #89938e; font-size: .857rem; }
+
+/* Update history */
+.updates-shell { min-height: 100vh; background: linear-gradient(180deg, #f3f8f6 0, #fff 420px); }
+.updates-header { display: flex; min-height: 72px; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); padding: 0 max(24px, calc((100vw - 1040px) / 2)); background: rgba(255,255,255,.86); backdrop-filter: blur(12px); }
+.updates-header > a:last-child { color: var(--accent); font-size: .857rem; font-weight: 800; }
+.updates-page, .update-detail-page { max-width: 1040px; margin: 0 auto; padding: 72px 30px 100px; }
+.updates-page > .lead { margin-bottom: 44px; }
+.update-detail-page .breadcrumbs { margin-bottom: 40px; }
+.update-detail-summary { display: flex; margin: 26px 0 54px; align-items: baseline; flex-wrap: wrap; gap: 10px; }
+.update-detail-summary > span { border-radius: 99px; padding: 8px 12px; background: white; box-shadow: inset 0 0 0 1px var(--line); color: var(--muted); font-size: .857rem; }
+.update-detail-summary strong { margin-left: 4px; color: var(--ink); font-size: 1rem; }
+.update-detail-summary small { color: #96a09b; }
+.update-change-section { margin-top: 48px; }
+.update-change-section > header { display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); padding-bottom: 12px; }
+.update-change-section h2 { margin: 0; font-size: 1.571rem; }
+.update-change-section > header span { min-width: 30px; border-radius: 99px; padding: 4px 8px; background: var(--soft); color: var(--muted); font-size: .786rem; font-weight: 800; text-align: center; }
+.update-change-section > p { color: var(--muted); }
+.update-change-list { display: flex; flex-direction: column; }
+.update-change-list > a, .update-change-list > div { display: grid; min-width: 0; align-items: center; grid-template-columns: minmax(180px, .8fr) minmax(280px, 1.2fr) auto; gap: 24px; border-bottom: 1px solid #edf0ee; padding: 15px 3px; }
+.update-change-list strong { overflow: hidden; font-size: .929rem; text-overflow: ellipsis; white-space: nowrap; }
+.update-change-list small { overflow: hidden; color: #8a9590; font-family: "SFMono-Regular", Consolas, monospace; font-size: .714rem; text-overflow: ellipsis; white-space: nowrap; }
+.update-change-list span { color: var(--accent); font-size: .786rem; font-weight: 800; }
+.update-change-list > a:hover strong { color: var(--accent); }
 
 button:focus-visible,
 a:focus-visible,
@@ -245,16 +291,17 @@ summary:focus-visible { outline: 3px solid rgba(8,122,87,.22); outline-offset: 3
   .sidebar-heading, .sidebar-note { display: none; }
   .sidebar-groups { display: flex; overflow-x: auto; gap: 6px; }
   .sidebar-groups details { flex: none; border: 0; }
-  .sidebar-group-link { flex: none; border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; }
   .sidebar-groups summary { border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; }
   .sidebar-groups summary::before, .sidebar-groups summary small { display: none; }
-  .sidebar-links { display: none; }
+  .sidebar-groups details[open] { width: min(280px, calc(100vw - 40px)); }
+  .sidebar-links { max-height: 260px; overflow-y: auto; padding: 7px 0; }
   .document-heading { display: block; }
   .reviewed-badge { display: inline-block; margin-top: 16px; }
   .source-notice { align-items: flex-start; flex-direction: column; }
   .section-entry-list { grid-template-columns: 1fr; }
   .home-header { padding: 0 18px; }
   .official-nav-link { display: none; }
+  .contact-trigger { padding: 0 5px; }
   .hero { padding-top: 72px; }
   .hero-actions { flex-direction: row; }
   .hero-actions a { padding-right: 14px; padding-left: 14px; }
@@ -269,7 +316,14 @@ summary:focus-visible { outline: 3px solid rgba(8,122,87,.22); outline-offset: 3
   .official-source > a { padding: 10px 12px; font-size: .857rem; }
   .collection-heading { align-items: flex-start; flex-direction: column; }
   .structure-grid { grid-template-columns: 1fr; }
-  .translation-list a { grid-template-columns: 1fr; gap: 7px; }
+  .update-batch-list > a { grid-template-columns: 1fr auto; gap: 14px; }
+  .update-batch-list dl { grid-column: 1 / -1; grid-row: 2; }
+  .update-batch-list > a > span { grid-column: 2; grid-row: 1; }
+  .updates-header { padding: 0 18px; }
+  .updates-page, .update-detail-page { padding: 52px 20px 80px; }
+  .update-change-list > a, .update-change-list > div { align-items: flex-start; grid-template-columns: 1fr auto; gap: 7px 16px; }
+  .update-change-list small { grid-column: 1 / -1; grid-row: 2; }
+  .update-change-list span { grid-column: 2; grid-row: 1; }
   .home-footer { align-items: flex-start; padding-top: 24px; padding-bottom: 24px; flex-direction: column; gap: 8px; }
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -37,7 +37,14 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="zh-CN">
-      <body>{children}</body>
+      <body>
+        {children}
+        <script
+          data-website-id="7136f50d-7292-484d-a837-e42bddae3a5f"
+          defer
+          src="https://analytics.xiexin.dev/script.js"
+        />
+      </body>
     </html>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,16 +1,19 @@
 import Link from "next/link";
 
+import { ContactPopover } from "@/components/contact-popover";
+import { UpdateBatchList } from "@/components/update-batch-list";
+
 import {
   sourceCheckSchedule,
   sourceGeneratedAt,
   translationGeneratedAt,
 } from "@/generated/documents";
 import {
-  availableDocuments,
   bilingualPageCount,
   localizedRoute,
   navigation,
   sourcePageCount,
+  syncReleases,
 } from "@/lib/documents";
 
 function formatBeijingTime(value: string): string {
@@ -26,8 +29,8 @@ function formatBeijingTime(value: string): string {
 }
 
 export default function Home() {
-  const translatedDocuments = availableDocuments("zh");
   const sections = navigation();
+  const releases = syncReleases();
 
   return (
     <main className="home-shell">
@@ -40,6 +43,7 @@ export default function Home() {
           </span>
         </Link>
         <nav>
+          <ContactPopover />
           <a
             className="official-nav-link"
             href="https://developers.openai.com/api/"
@@ -139,23 +143,16 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="translated-section" aria-labelledby="translated-title">
+      <section className="updates-section" aria-labelledby="updates-title">
         <div className="collection-heading">
           <div>
-            <p className="eyebrow">中文翻译</p>
-            <h2 id="translated-title">当前可读的中文译文</h2>
+            <p className="eyebrow">更新记录</p>
+            <h2 id="updates-title">文档更新批次</h2>
           </div>
-          <span>译文会留在对应官网目录位置，并持续随同步流程增加</span>
+          <Link href="/updates">查看全部更新 →</Link>
         </div>
-        <div className="translation-list">
-          {translatedDocuments.map((document) => (
-            <Link href={localizedRoute("zh", document.route)} key={document.route}>
-              <span>{document.section === "reference" ? "API 参考" : "文档指南"}</span>
-              <strong>{document.title}</strong>
-              <small>{document.reviewStatus === "reviewed" ? "人工校对" : "机器翻译"} →</small>
-            </Link>
-          ))}
-        </div>
+        <p className="updates-intro">每次自动同步都会留下批次记录，包含更新时间和具体的新增、修改、删除文章。</p>
+        <UpdateBatchList releases={releases.slice(0, 8)} />
       </section>
 
       <footer className="home-footer">

--- a/apps/web/app/updates/[id]/page.tsx
+++ b/apps/web/app/updates/[id]/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import {
+  documentMetadataForRoute,
+  localizedRoute,
+  syncReleaseById,
+  syncReleases,
+  type SyncReleaseEntry,
+} from "@/lib/documents";
+
+function formatBatchTime(value: string): string {
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "full",
+    timeStyle: "short",
+    timeZone: "Asia/Shanghai",
+  }).format(new Date(value));
+}
+
+function ChangeSection({
+  entries,
+  kind,
+  title,
+}: {
+  entries: readonly SyncReleaseEntry[];
+  kind: "added" | "modified" | "removed";
+  title: string;
+}) {
+  const titleFor = (entry: SyncReleaseEntry) =>
+    documentMetadataForRoute("zh", entry.route)?.title ?? entry.title;
+
+  return (
+    <section className={`update-change-section ${kind}`}>
+      <header><h2>{title}</h2><span>{entries.length}</span></header>
+      {entries.length === 0 ? <p>本批次没有{title}。</p> : (
+        <div className="update-change-list">
+          {entries.map((entry) => kind === "removed" ? (
+            <div key={entry.path}><strong>{titleFor(entry)}</strong><small>{entry.path}</small></div>
+          ) : (
+            <Link href={localizedRoute("zh", entry.route)} key={entry.path}>
+              <strong>{titleFor(entry)}</strong><small>{entry.path}</small><span>打开文档 →</span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function generateStaticParams() {
+  return syncReleases().map((release) => ({ id: release.id }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const release = syncReleaseById((await params).id);
+  return release ? {
+    title: `文档更新 · ${formatBatchTime(release.generatedAt)}`,
+    description: `新增 ${release.added.length} 篇，修改 ${release.modified.length} 篇，删除 ${release.removed.length} 篇。`,
+  } : {};
+}
+
+export default async function UpdateDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const release = syncReleaseById((await params).id);
+  if (!release) notFound();
+
+  return (
+    <main className="updates-shell">
+      <header className="updates-header">
+        <Link className="brand" href="/">
+          <span aria-hidden="true" className="brand-line" />
+          <span><strong>OpenAI API 文档</strong><small>中文社区翻译 · 同步官方 Markdown</small></span>
+        </Link>
+        <Link href="/updates">全部更新</Link>
+      </header>
+      <article className="update-detail-page">
+        <div className="breadcrumbs"><Link href="/">首页</Link><span>/</span><Link href="/updates">文档更新</Link></div>
+        <p className="eyebrow">同步批次</p>
+        <h1>{formatBatchTime(release.generatedAt)}</h1>
+        <div className="update-detail-summary">
+          <span>新增 <strong>{release.added.length}</strong></span>
+          <span>修改 <strong>{release.modified.length}</strong></span>
+          <span>删除 <strong>{release.removed.length}</strong></span>
+          <small>北京时间</small>
+        </div>
+        <ChangeSection entries={release.added} kind="added" title="新增文章" />
+        <ChangeSection entries={release.modified} kind="modified" title="修改文章" />
+        <ChangeSection entries={release.removed} kind="removed" title="删除文章" />
+      </article>
+    </main>
+  );
+}

--- a/apps/web/app/updates/page.tsx
+++ b/apps/web/app/updates/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { UpdateBatchList } from "@/components/update-batch-list";
+import { syncReleases } from "@/lib/documents";
+
+export const metadata: Metadata = {
+  title: "文档更新记录",
+  description: "查看 OpenAI API 中文文档每次自动同步的文章变更。",
+};
+
+export default function UpdatesPage() {
+  return (
+    <main className="updates-shell">
+      <header className="updates-header">
+        <Link className="brand" href="/">
+          <span aria-hidden="true" className="brand-line" />
+          <span><strong>OpenAI API 文档</strong><small>中文社区翻译 · 同步官方 Markdown</small></span>
+        </Link>
+        <Link href="/">返回首页</Link>
+      </header>
+      <article className="updates-page">
+        <p className="eyebrow">Release 信息</p>
+        <h1>文档更新记录</h1>
+        <p className="lead">按批次追踪官方文档同步结果，查看每次新增、修改和删除的具体文章。</p>
+        <UpdateBatchList releases={syncReleases()} />
+      </article>
+    </main>
+  );
+}

--- a/apps/web/components/contact-popover.tsx
+++ b/apps/web/components/contact-popover.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+
+const CONTACT_IMAGE =
+  "https://jiahim-picgo.oss-cn-shenzhen.aliyuncs.com/img/xhs.jpg";
+
+export function ContactPopover() {
+  const [open, setOpen] = useState(false);
+  const [pinned, setPinned] = useState(false);
+
+  return (
+    <div
+      className="contact-popover"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+          setPinned(false);
+        }
+      }}
+      onFocus={() => setOpen(true)}
+      onPointerEnter={(event) => {
+        if (event.pointerType !== "touch") setOpen(true);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType !== "touch" && !pinned) setOpen(false);
+      }}
+    >
+      <button
+        aria-controls="contact-qr-popover"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label="查看 JiaHim 的小红书二维码"
+        className={open ? "contact-trigger active" : "contact-trigger"}
+        onClick={() => {
+          setPinned((current) => {
+            const next = !current;
+            setOpen(next);
+            return next;
+          });
+        }}
+        type="button"
+      >
+        <span aria-hidden="true" />
+        找到我
+      </button>
+      <div
+        aria-hidden={!open}
+        aria-label="JiaHim 的小红书二维码"
+        className={open ? "contact-card open" : "contact-card"}
+        id="contact-qr-popover"
+        role="dialog"
+      >
+        <div>
+          {open && (
+            // The owner asked to keep using the reference site's remote image.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt="JiaHim（科技版）的小红书二维码，小红书号 sam12138"
+              draggable={false}
+              height="1347"
+              src={CONTACT_IMAGE}
+              width="987"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/document-reader.tsx
+++ b/apps/web/components/document-reader.tsx
@@ -21,6 +21,7 @@ import {
   navigationNeighbors,
   navigationSectionForRoute,
   oppositeLocale,
+  sidebarNavigationGroups,
 } from "@/lib/documents";
 import { resolveDocumentAsset, rewriteDocumentLink } from "@/lib/links";
 
@@ -66,6 +67,14 @@ function nodeText(node: ReactNode): string {
     return nodeText((node as { props: { children?: ReactNode } }).props.children);
   }
   return "";
+}
+
+function formatDocumentTime(value: string, locale: Locale): string {
+  return new Intl.DateTimeFormat(locale === "zh" ? "zh-CN" : "en-GB", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Shanghai",
+  }).format(new Date(value));
 }
 
 function markdownComponents(document: GeneratedDocument): Components {
@@ -160,11 +169,11 @@ function DocsSidebar({ locale, route }: { locale: Locale; route: string }) {
         <strong>{section.groups.reduce((total, group) => total + group.entries.length, 0)}</strong>
       </div>
       <div className="sidebar-groups">
-        {section.groups.map((group) => activeGroup?.title === group.title ? (
-          <details key={group.title} open>
+        {sidebarNavigationGroups(section).map((group) => (
+          <details key={group.title} open={activeGroup?.title === group.title}>
             <summary>
               <span>{groupLabel(locale, group.title)}</span>
-              <small>{group.entries.length + group.externalEntries.length}</small>
+              <small>{group.entries.length}</small>
             </summary>
             <div className="sidebar-links">
               {group.entries.map((entry) => {
@@ -182,15 +191,6 @@ function DocsSidebar({ locale, route }: { locale: Locale; route: string }) {
               })}
             </div>
           </details>
-        ) : (
-          <Link
-            className="sidebar-group-link"
-            href={`${localizedRoute(locale, section.route)}#${headingSlug(group.title)}`}
-            key={group.title}
-          >
-            <span>{groupLabel(locale, group.title)}</span>
-            <small>{group.entries.length + group.externalEntries.length}</small>
-          </Link>
         ))}
       </div>
       <div className="sidebar-note">
@@ -261,7 +261,6 @@ export function DocumentReader({ document }: { document: GeneratedDocument }) {
           <div>
             <p className="eyebrow">{group ? groupLabel(locale, group.title) : sectionLabel(locale, section)}</p>
             <h1>{document.title}</h1>
-            {document.description && <p className="lead">{document.description}</p>}
           </div>
           <span className={`reviewed-badge ${document.reviewStatus}`}>
             {isSource
@@ -271,6 +270,28 @@ export function DocumentReader({ document }: { document: GeneratedDocument }) {
                 : locale === "zh" ? "机器翻译" : "Machine translated"}
           </span>
         </div>
+
+        <dl className="document-timestamps">
+          <div>
+            <dt>{locale === "zh" ? "英文原文拉取" : "English source pulled"}</dt>
+            <dd>
+              <time dateTime={document.sourceUpdatedAt}>
+                {formatDocumentTime(document.sourceUpdatedAt, locale)}
+              </time>
+            </dd>
+          </div>
+          {locale === "zh" && document.translatedAt && (
+            <div>
+              <dt>中文翻译完成</dt>
+              <dd>
+                <time dateTime={document.translatedAt}>
+                  {formatDocumentTime(document.translatedAt, locale)}
+                </time>
+              </dd>
+            </div>
+          )}
+          <span>{locale === "zh" ? "北京时间" : "China Standard Time"}</span>
+        </dl>
 
         <div className="source-notice">
           <span>

--- a/apps/web/components/update-batch-list.tsx
+++ b/apps/web/components/update-batch-list.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+import type { SyncRelease } from "@/lib/documents";
+
+function formatBatchTime(value: string): string {
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "long",
+    timeStyle: "short",
+    timeZone: "Asia/Shanghai",
+  }).format(new Date(value));
+}
+
+export function UpdateBatchList({
+  releases,
+}: {
+  releases: readonly SyncRelease[];
+}) {
+  return (
+    <div className="update-batch-list">
+      {releases.map((release) => (
+        <Link href={`/updates/${release.id}`} key={release.id}>
+          <div>
+            <time dateTime={release.generatedAt}>{formatBatchTime(release.generatedAt)}</time>
+            <strong>官方文档同步批次</strong>
+          </div>
+          <dl>
+            <div className="added"><dt>新增</dt><dd>{release.added.length}</dd></div>
+            <div className="modified"><dt>修改</dt><dd>{release.modified.length}</dd></div>
+            <div className="removed"><dt>删除</dt><dd>{release.removed.length}</dd></div>
+          </dl>
+          <span>查看详情 →</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/lib/document-content.ts
+++ b/apps/web/lib/document-content.ts
@@ -27,6 +27,21 @@ function markdownHeadings(markdown: string): Array<{ depth: 2 | 3; text: string 
   return result;
 }
 
+export function removeOfficialIndexNotice(markdown: string): string {
+  return markdown
+    .split(/\r?\n/u)
+    .filter((line) => {
+      const normalized = line.trim();
+      return !(
+        normalized.startsWith(">") &&
+        normalized.includes("[llms.txt](/llms.txt)") &&
+        normalized.includes("`.md`")
+      );
+    })
+    .join("\n")
+    .replace(/\n{3,}/gu, "\n\n");
+}
+
 export async function loadDocumentForRoute(
   locale: Locale,
   route: string,
@@ -46,6 +61,6 @@ export async function loadDocumentForRoute(
   if (!contentPath.startsWith(contentRoot + sep)) {
     throw new Error(`文档路径越界：${metadata.contentPath}`);
   }
-  const markdown = await readFile(contentPath, "utf8");
+  const markdown = removeOfficialIndexNotice(await readFile(contentPath, "utf8"));
   return { ...metadata, markdown, headings: markdownHeadings(markdown) };
 }

--- a/apps/web/lib/documents.ts
+++ b/apps/web/lib/documents.ts
@@ -2,6 +2,7 @@ import {
   documentCatalog,
   generatedDocuments,
   navigationSections,
+  syncReleases as generatedSyncReleases,
 } from "@/generated/documents";
 
 export type Locale = "en" | "zh";
@@ -15,6 +16,8 @@ export interface DocumentMetadata {
   contentPath: string;
   section: "guides" | "reference";
   sourceUrl: string;
+  sourceUpdatedAt: string;
+  translatedAt?: string;
   reviewStatus: "machine" | "reviewed" | "source";
 }
 
@@ -31,6 +34,7 @@ export interface CatalogDocument {
   contentPath: string;
   section: "guides" | "reference";
   sourceUrl: string;
+  sourceUpdatedAt: string;
 }
 
 export type NavigationEntry = CatalogDocument;
@@ -51,6 +55,21 @@ export interface NavigationSection {
   title: string;
   description: string;
   groups: readonly NavigationGroup[];
+}
+
+export interface SyncReleaseEntry {
+  path: string;
+  route: string;
+  sourceUrl: string;
+  title: string;
+}
+
+export interface SyncRelease {
+  added: readonly SyncReleaseEntry[];
+  generatedAt: string;
+  id: string;
+  modified: readonly SyncReleaseEntry[];
+  removed: readonly SyncReleaseEntry[];
 }
 
 export function isLocale(value: string): value is Locale {
@@ -90,6 +109,22 @@ export function availableDocuments(locale: Locale): DocumentMetadata[] {
 
 export function navigation(): readonly NavigationSection[] {
   return navigationSections as readonly NavigationSection[];
+}
+
+export function sidebarNavigationGroups(
+  section: NavigationSection,
+): readonly NavigationGroup[] {
+  return section.groups
+    .filter((group) => group.entries.length > 0)
+    .map((group) => ({ ...group, externalEntries: [] }));
+}
+
+export function syncReleases(): readonly SyncRelease[] {
+  return generatedSyncReleases as readonly SyncRelease[];
+}
+
+export function syncReleaseById(id: string): SyncRelease | undefined {
+  return syncReleases().find((release) => release.id === id);
 }
 
 export function navigationSectionForRoute(

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["127.0.0.1"],
   output: "export",
   outputFileTracingExcludes: {
     "/*": ["../../docs/**/*"],

--- a/apps/web/scripts/generate-content.ts
+++ b/apps/web/scripts/generate-content.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,7 @@ interface SourcePageRecord {
   localPath: string;
   section: "guides" | "reference";
   sourceUrl: string;
+  sourceUpdatedAt: string;
   status: "active" | "removed";
   title: string;
 }
@@ -22,6 +23,7 @@ interface TranslationPageRecord {
   sourcePath: string;
   sourceUrl: string;
   targetPath: string;
+  translatedAt: string;
 }
 
 interface TranslationManifest {
@@ -55,7 +57,24 @@ interface ContentRecord {
   route: string;
   section: "guides" | "reference";
   sourceUrl: string;
+  sourceUpdatedAt: string;
   title: string;
+  translatedAt?: string;
+}
+
+interface SyncReleaseEntry {
+  path: string;
+  route: string;
+  sourceUrl: string;
+  title: string;
+}
+
+interface SyncReleaseRecord {
+  added: SyncReleaseEntry[];
+  generatedAt: string;
+  id: string;
+  modified: SyncReleaseEntry[];
+  removed: SyncReleaseEntry[];
 }
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -79,28 +98,6 @@ function routeFromSourceUrl(sourceUrl: string): string {
 
 function firstHeading(markdown: string, fallback: string): string {
   return markdown.match(/^#\s+(.+)$/mu)?.[1]?.trim() || fallback;
-}
-
-function pageDescription(markdown: string, fallback: string): string {
-  const lines = markdown.split(/\r?\n/u);
-  let inFence = false;
-  for (const rawLine of lines) {
-    const line = rawLine.trim();
-    if (line.startsWith("```")) {
-      inFence = !inFence;
-      continue;
-    }
-    if (
-      inFence ||
-      !line ||
-      /^#{1,6}\s/u.test(line) ||
-      /^(?:>|[-*+] |\d+\. |\||<)/u.test(line)
-    ) {
-      continue;
-    }
-    return line.replace(/\[([^\]]+)\]\([^)]+\)/gu, "$1").slice(0, 180);
-  }
-  return fallback;
 }
 
 function beijingScheduleFromWorkflow(workflow: string): string {
@@ -161,7 +158,8 @@ function navigationGroups(
 }
 
 async function main(): Promise<void> {
-  const [sourceManifest, translationManifest, docsIndex, referenceIndex, syncWorkflow] = await Promise.all([
+  const updatesRoot = resolve(repositoryRoot, "docs/updates");
+  const [sourceManifest, translationManifest, docsIndex, referenceIndex, syncWorkflow, updateFiles] = await Promise.all([
     readFile(resolve(repositoryRoot, "docs/en/.source-manifest.json"), "utf8").then(
       (value) => JSON.parse(value) as SourceManifest,
     ),
@@ -171,7 +169,20 @@ async function main(): Promise<void> {
     readFile(resolve(repositoryRoot, "docs/en/api/docs/llms.txt"), "utf8"),
     readFile(resolve(repositoryRoot, "docs/en/api/reference/llms.txt"), "utf8"),
     readFile(resolve(repositoryRoot, ".github/workflows/sync-docs.yml"), "utf8"),
+    readdir(updatesRoot).catch((error: unknown) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }),
   ]);
+
+  const syncReleases = await Promise.all(
+    updateFiles
+      .filter((fileName) => fileName.endsWith(".json"))
+      .map((fileName) => readFile(resolve(updatesRoot, fileName), "utf8").then(
+        (value) => JSON.parse(value) as SyncReleaseRecord,
+      )),
+  );
+  syncReleases.sort((left, right) => right.generatedAt.localeCompare(left.generatedAt));
 
   const catalog = Object.values(sourceManifest.pages)
     .filter((page) => page.status === "active")
@@ -181,6 +192,7 @@ async function main(): Promise<void> {
       description: page.description,
       section: page.section,
       sourceUrl: page.sourceUrl,
+      sourceUpdatedAt: page.sourceUpdatedAt,
       contentPath: page.localPath,
       bytes: page.bytes,
     }))
@@ -236,6 +248,7 @@ async function main(): Promise<void> {
     bytes: page.bytes,
     section: page.section,
     sourceUrl: page.sourceUrl,
+    sourceUpdatedAt: page.sourceUpdatedAt,
     reviewStatus: "source",
   }));
   for (const page of Object.values(translationManifest.pages)) {
@@ -247,11 +260,15 @@ async function main(): Promise<void> {
       locale: "zh",
       route,
       title: firstHeading(chinese, catalogPage.title),
-      description: pageDescription(chinese, catalogPage.description),
+      // Chinese page metadata must come from an explicitly translated field.
+      // Never infer it from article body text, which would duplicate and reorder content.
+      description: "",
       contentPath: page.targetPath,
       bytes: Buffer.byteLength(chinese, "utf8"),
       section: catalogPage.section,
       sourceUrl: page.sourceUrl,
+      sourceUpdatedAt: catalogPage.sourceUpdatedAt,
+      translatedAt: page.translatedAt,
       reviewStatus: page.reviewStatus,
     });
   }
@@ -264,6 +281,7 @@ async function main(): Promise<void> {
     `export const sourceGeneratedAt = ${JSON.stringify(sourceManifest.generatedAt)};\n` +
     `export const translationGeneratedAt = ${JSON.stringify(translationManifest.generatedAt)};\n` +
     `export const sourceCheckSchedule = ${JSON.stringify(beijingScheduleFromWorkflow(syncWorkflow))};\n` +
+    `export const syncReleases = ${JSON.stringify(syncReleases, null, 2)} as const;\n` +
     `export const documentCatalog = ${JSON.stringify(catalog, null, 2)} as const;\n` +
     `export const navigationSections = ${JSON.stringify(navigationSections, null, 2)} as const;\n` +
     `export const generatedDocuments = ${JSON.stringify(documents, null, 2)} as const;\n`;

--- a/apps/web/tests/document-content.test.ts
+++ b/apps/web/tests/document-content.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DocumentReader } from "../components/document-reader.js";
+import { generatedDocuments } from "../generated/documents.js";
+import {
+  loadDocumentForRoute,
+  removeOfficialIndexNotice,
+} from "../lib/document-content.js";
+import {
+  documentMetadataForRoute,
+  navigation,
+  sidebarNavigationGroups,
+  syncReleases,
+} from "../lib/documents.js";
+
+test("removes the official llms.txt and Markdown boilerplate notice", () => {
+  const markdown = [
+    "# GPT Actions 库",
+    "",
+    "> 如需查看完整的文档索引，请参阅 [llms.txt](/llms.txt)。文档页面的 Markdown 版本可通过在页面 URL 后追加 `.md` 获取。",
+    "",
+    "## 目的",
+    "",
+    "正文",
+  ].join("\n");
+
+  assert.equal(
+    removeOfficialIndexNotice(markdown),
+    ["# GPT Actions 库", "", "## 目的", "", "正文"].join("\n"),
+  );
+});
+
+test("keeps unrelated blockquotes", () => {
+  const markdown = "> 这是需要保留的正文提示。\n\n正文";
+  assert.equal(removeOfficialIndexNotice(markdown), markdown);
+});
+
+test("exposes source pull and translation timestamps for localized pages", () => {
+  const document = documentMetadataForRoute(
+    "zh",
+    "/api/docs/actions/actions-library",
+  );
+
+  assert.ok(document?.sourceUpdatedAt);
+  assert.ok(document.translatedAt);
+  assert.ok(Number.isFinite(Date.parse(document.sourceUpdatedAt)));
+  assert.ok(Number.isFinite(Date.parse(document.translatedAt)));
+});
+
+test("never derives Chinese page metadata descriptions from article body text", () => {
+  const localizedDocuments = generatedDocuments.filter(
+    (document) => document.locale === "zh",
+  );
+
+  assert.ok(localizedDocuments.length > 400);
+  for (const document of localizedDocuments) {
+    assert.equal(
+      document.description,
+      "",
+      `${document.route} has an inferred description`,
+    );
+  }
+});
+
+test("renders every document header in title, timestamps, source notice, body order", async () => {
+  const document = await loadDocumentForRoute(
+    "zh",
+    "/api/docs/actions/getting-started",
+  );
+  assert.ok(document);
+
+  const html = renderToStaticMarkup(createElement(DocumentReader, { document }));
+  const titleIndex = html.indexOf("<h1>");
+  const timestampsIndex = html.indexOf('class="document-timestamps"');
+  const sourceNoticeIndex = html.indexOf('class="source-notice"');
+  const bodyIndex = html.indexOf('class="markdown-body"');
+
+  assert.ok(titleIndex >= 0);
+  assert.ok(titleIndex < timestampsIndex);
+  assert.ok(timestampsIndex < sourceNoticeIndex);
+  assert.ok(sourceNoticeIndex < bodyIndex);
+  assert.equal(
+    html.match(/新南威尔士州国家气象局/gu)?.length,
+    1,
+    "article body must not be duplicated into the document header",
+  );
+});
+
+test("keeps external document bundles out of the ordinary article sidebar", () => {
+  for (const section of navigation()) {
+    const sidebarGroups = sidebarNavigationGroups(section);
+    assert.ok(sidebarGroups.every((group) => group.entries.length > 0));
+    assert.ok(
+      sidebarGroups.every((group) => group.externalEntries.length === 0),
+    );
+  }
+});
+
+test("ships update batches with article-level change details", () => {
+  const release = syncReleases()[0];
+  assert.ok(release);
+  assert.equal(release.added.length, 1);
+  assert.equal(release.modified.length, 56);
+  assert.equal(release.removed.length, 0);
+  assert.equal(release.added[0]?.title, "Mutual TLS");
+});
+
+test("keeps the requested contact image and analytics identifiers", async () => {
+  const [contact, layout] = await Promise.all([
+    readFile(resolve("components/contact-popover.tsx"), "utf8"),
+    readFile(resolve("app/layout.tsx"), "utf8"),
+  ]);
+
+  assert.match(
+    contact,
+    /https:\/\/jiahim-picgo\.oss-cn-shenzhen\.aliyuncs\.com\/img\/xhs\.jpg/u,
+  );
+  assert.match(layout, /https:\/\/analytics\.xiexin\.dev\/script\.js/u);
+  assert.match(layout, /7136f50d-7292-484d-a837-e42bddae3a5f/u);
+});

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -37,7 +37,7 @@ docs/en/api/docs/guides/images-vision.md
 
 manifest 不保存 API key、完整模型响应或供应商凭据。
 
-翻译配置因加入必填的 `priorityPath` 使用 `schemaVersion: 2`；术语表、优先级配置和 translation manifest 使用各自的 `schemaVersion: 1`。持久化记录拒绝未知字段、非规范路径、重复 source/target 路径和无效 UTC 时间；所有读取都必须解析真实路径并拒绝逃逸仓库的符号链接。术语表以排序后的语义内容参与策略哈希，JSON 排版和对象键顺序不影响增量状态。
+翻译配置使用 `schemaVersion: 2`，并可通过 `reviewNotesPath` 指向页面级审核备注；术语表、优先级配置、页面级审核备注和 translation manifest 使用各自的 `schemaVersion: 1`。持久化记录拒绝未知字段、非规范路径、重复 source/target 路径和无效 UTC 时间；所有读取都必须解析真实路径并拒绝逃逸仓库的符号链接。术语表以排序后的语义内容参与基础策略哈希，JSON 排版和对象键顺序不影响增量状态；页面级备注只参与对应 source URL 的页面策略哈希，因此不会使无关译文过期。
 
 ## 状态机与覆盖安全
 
@@ -77,7 +77,8 @@ render 会安全移除模型偶发添加在译文单元首尾的空白，同时�
 - 批量任务默认低并发，先支持 `--section`、`--match` 和 `--limit`，再开放全量运行。
 - 质量检查至少覆盖：Markdown 可重新解析、保护内容一致、无空译文、链接目标一致、代码块一致、manifest/文件 SHA 一致。
 - 机器译文以 PR 形式进入 `main`；人工校对只提升 `reviewStatus`，英文或策略变化后仍会重新标记 stale。
-- 人工润色会先自然进入 `modified-target`；显式 `translate:review` 只在源与策略仍有效、且中英文 Markdown 受保护结构一致时收录新的目标 SHA，并把记录提升为 `reviewed`。
+- 人工润色会先自然进入 `modified-target`；显式 `translate:review` 只在英文来源仍有效、且中英文 Markdown 受保护结构一致时收录新的目标 SHA，并把记录提升为 `reviewed`。如果同一 PR 新增了页面级备注，显式审核会同时采用该页当前策略 SHA；只新增备注但没有人工润色时仍保持 `stale-policy`，必须重新翻译。
+- 人工审核反馈按作用域沉淀：固定译法进入术语表，通用要求进入提示词，可自动判断的问题进入质量门和回归测试，单页上下文与官方原文勘误进入页面级审核备注。Runner 只向匹配 source URL 的翻译请求追加对应备注。
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 

--- a/docs/updates/2026-08-26T16-49-10-000Z.json
+++ b/docs/updates/2026-08-26T16-49-10-000Z.json
@@ -1,0 +1,351 @@
+{
+  "id": "2026-08-26T16-49-10-000Z",
+  "generatedAt": "2026-08-26T16:49:10Z",
+  "added": [
+    {
+      "path": "docs/en/api/docs/guides/mutual-tls.md",
+      "route": "/api/docs/guides/mutual-tls",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/mutual-tls.md",
+      "title": "Mutual TLS"
+    }
+  ],
+  "modified": [
+    {
+      "path": "docs/en/api/docs/guides/audio.md",
+      "route": "/api/docs/guides/audio",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/audio.md",
+      "title": "Audio and speech"
+    },
+    {
+      "path": "docs/en/api/docs/guides/citation-formatting.md",
+      "route": "/api/docs/guides/citation-formatting",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/citation-formatting.md",
+      "title": "Citation Formatting"
+    },
+    {
+      "path": "docs/en/api/docs/guides/conversation-state.md",
+      "route": "/api/docs/guides/conversation-state",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/conversation-state.md",
+      "title": "Conversation state"
+    },
+    {
+      "path": "docs/en/api/docs/guides/direct-preference-optimization.md",
+      "route": "/api/docs/guides/direct-preference-optimization",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/direct-preference-optimization.md",
+      "title": "Direct preference optimization"
+    },
+    {
+      "path": "docs/en/api/docs/guides/embeddings.md",
+      "route": "/api/docs/guides/embeddings",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/embeddings.md",
+      "title": "Vector embeddings"
+    },
+    {
+      "path": "docs/en/api/docs/guides/error-codes.md",
+      "route": "/api/docs/guides/error-codes",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/error-codes.md",
+      "title": "Error codes"
+    },
+    {
+      "path": "docs/en/api/docs/guides/evals.md",
+      "route": "/api/docs/guides/evals",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/evals.md",
+      "title": "Working with evals"
+    },
+    {
+      "path": "docs/en/api/docs/guides/function-calling.md",
+      "route": "/api/docs/guides/function-calling",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/function-calling.md",
+      "title": "Function calling"
+    },
+    {
+      "path": "docs/en/api/docs/guides/graders.md",
+      "route": "/api/docs/guides/graders",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/graders.md",
+      "title": "Graders"
+    },
+    {
+      "path": "docs/en/api/docs/guides/image-generation.md",
+      "route": "/api/docs/guides/image-generation",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/image-generation.md",
+      "title": "Image generation"
+    },
+    {
+      "path": "docs/en/api/docs/guides/images-vision.md",
+      "route": "/api/docs/guides/images-vision",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/images-vision.md",
+      "title": "Images and vision"
+    },
+    {
+      "path": "docs/en/api/docs/guides/latency-optimization.md",
+      "route": "/api/docs/guides/latency-optimization",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/latency-optimization.md",
+      "title": "Latency optimization"
+    },
+    {
+      "path": "docs/en/api/docs/guides/migrate-to-responses.md",
+      "route": "/api/docs/guides/migrate-to-responses",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/migrate-to-responses.md",
+      "title": "Migrate to the Responses API"
+    },
+    {
+      "path": "docs/en/api/docs/guides/moderation.md",
+      "route": "/api/docs/guides/moderation",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/moderation.md",
+      "title": "Moderation"
+    },
+    {
+      "path": "docs/en/api/docs/guides/optimizing-llm-accuracy.md",
+      "route": "/api/docs/guides/optimizing-llm-accuracy",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/optimizing-llm-accuracy.md",
+      "title": "Optimizing LLM Accuracy"
+    },
+    {
+      "path": "docs/en/api/docs/guides/prompt-caching.md",
+      "route": "/api/docs/guides/prompt-caching",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/prompt-caching.md",
+      "title": "Prompt caching"
+    },
+    {
+      "path": "docs/en/api/docs/guides/prompt-engineering.md",
+      "route": "/api/docs/guides/prompt-engineering",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/prompt-engineering.md",
+      "title": "Prompt engineering"
+    },
+    {
+      "path": "docs/en/api/docs/guides/rate-limits.md",
+      "route": "/api/docs/guides/rate-limits",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/rate-limits.md",
+      "title": "Rate limits"
+    },
+    {
+      "path": "docs/en/api/docs/guides/realtime-models-prompting.md",
+      "route": "/api/docs/guides/realtime-models-prompting",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/realtime-models-prompting.md",
+      "title": "Using realtime models"
+    },
+    {
+      "path": "docs/en/api/docs/guides/reasoning.md",
+      "route": "/api/docs/guides/reasoning",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/reasoning.md",
+      "title": "Reasoning models"
+    },
+    {
+      "path": "docs/en/api/docs/guides/reinforcement-fine-tuning.md",
+      "route": "/api/docs/guides/reinforcement-fine-tuning",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/reinforcement-fine-tuning.md",
+      "title": "Reinforcement fine-tuning"
+    },
+    {
+      "path": "docs/en/api/docs/guides/retrieval.md",
+      "route": "/api/docs/guides/retrieval",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/retrieval.md",
+      "title": "Retrieval"
+    },
+    {
+      "path": "docs/en/api/docs/guides/speech-to-text.md",
+      "route": "/api/docs/guides/speech-to-text",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/speech-to-text.md",
+      "title": "File transcription"
+    },
+    {
+      "path": "docs/en/api/docs/guides/structured-outputs.md",
+      "route": "/api/docs/guides/structured-outputs",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/structured-outputs.md",
+      "title": "Structured model outputs"
+    },
+    {
+      "path": "docs/en/api/docs/guides/supervised-fine-tuning.md",
+      "route": "/api/docs/guides/supervised-fine-tuning",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/supervised-fine-tuning.md",
+      "title": "Supervised fine-tuning"
+    },
+    {
+      "path": "docs/en/api/docs/guides/text-to-speech.md",
+      "route": "/api/docs/guides/text-to-speech",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/text-to-speech.md",
+      "title": "Text to speech"
+    },
+    {
+      "path": "docs/en/api/docs/guides/text.md",
+      "route": "/api/docs/guides/text",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/text.md",
+      "title": "Text generation"
+    },
+    {
+      "path": "docs/en/api/docs/guides/tools-computer-use.md",
+      "route": "/api/docs/guides/tools-computer-use",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/tools-computer-use.md",
+      "title": "Computer use"
+    },
+    {
+      "path": "docs/en/api/docs/guides/tools-connectors-mcp.md",
+      "route": "/api/docs/guides/tools-connectors-mcp",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/tools-connectors-mcp.md",
+      "title": "MCP and Connectors"
+    },
+    {
+      "path": "docs/en/api/docs/guides/tools-file-search.md",
+      "route": "/api/docs/guides/tools-file-search",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/tools-file-search.md",
+      "title": "File search"
+    },
+    {
+      "path": "docs/en/api/docs/guides/tools.md",
+      "route": "/api/docs/guides/tools",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/tools.md",
+      "title": "Using tools"
+    },
+    {
+      "path": "docs/en/api/docs/guides/vision-fine-tuning.md",
+      "route": "/api/docs/guides/vision-fine-tuning",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/vision-fine-tuning.md",
+      "title": "Vision fine-tuning"
+    },
+    {
+      "path": "docs/en/api/docs/guides/workload-identity-federation.md",
+      "route": "/api/docs/guides/workload-identity-federation",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/workload-identity-federation.md",
+      "title": "Workload identity federation"
+    },
+    {
+      "path": "docs/en/api/docs/guides/workload-identity-federation/x509.md",
+      "route": "/api/docs/guides/workload-identity-federation/x509",
+      "sourceUrl": "https://developers.openai.com/api/docs/guides/workload-identity-federation/x509.md",
+      "title": "Configure workload identity federation with X.509 certificates"
+    },
+    {
+      "path": "docs/en/api/docs/mcp.md",
+      "route": "/api/docs/mcp",
+      "sourceUrl": "https://developers.openai.com/api/docs/mcp.md",
+      "title": "Building MCP servers for plugins and API integrations"
+    },
+    {
+      "path": "docs/en/api/docs/models.md",
+      "route": "/api/docs/models",
+      "sourceUrl": "https://developers.openai.com/api/docs/models.md",
+      "title": "Models"
+    },
+    {
+      "path": "docs/en/api/docs/models/all.md",
+      "route": "/api/docs/models/all",
+      "sourceUrl": "https://developers.openai.com/api/docs/models/all.md",
+      "title": "All models"
+    },
+    {
+      "path": "docs/en/api/docs/quickstart.md",
+      "route": "/api/docs/quickstart",
+      "sourceUrl": "https://developers.openai.com/api/docs/quickstart.md",
+      "title": "Developer quickstart"
+    },
+    {
+      "path": "docs/en/api/docs/supported-countries.md",
+      "route": "/api/docs/supported-countries",
+      "sourceUrl": "https://developers.openai.com/api/docs/supported-countries.md",
+      "title": "Supported countries and territories"
+    },
+    {
+      "path": "docs/en/api/docs/tutorials/web-qa-embeddings.md",
+      "route": "/api/docs/tutorials/web-qa-embeddings",
+      "sourceUrl": "https://developers.openai.com/api/docs/tutorials/web-qa-embeddings.md",
+      "title": "Web QA with embeddings"
+    },
+    {
+      "path": "docs/en/api/reference/resources/beta/subresources/responses/streaming-events.md",
+      "route": "/api/reference/resources/beta/subresources/responses/streaming-events",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/beta/subresources/responses/streaming-events.md",
+      "title": "Beta Responses streaming events"
+    },
+    {
+      "path": "docs/en/api/reference/resources/beta/subresources/responses/websocket-events.md",
+      "route": "/api/reference/resources/beta/subresources/responses/websocket-events",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/beta/subresources/responses/websocket-events.md",
+      "title": "Beta Responses WebSocket events"
+    },
+    {
+      "path": "docs/en/api/reference/resources/conversations.md",
+      "route": "/api/reference/resources/conversations",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/conversations.md",
+      "title": "Conversations"
+    },
+    {
+      "path": "docs/en/api/reference/resources/conversations/methods/create.md",
+      "route": "/api/reference/resources/conversations/methods/create",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/conversations/methods/create.md",
+      "title": "Conversations — Create"
+    },
+    {
+      "path": "docs/en/api/reference/resources/realtime.md",
+      "route": "/api/reference/resources/realtime",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/realtime.md",
+      "title": "Realtime"
+    },
+    {
+      "path": "docs/en/api/reference/resources/realtime/subresources/calls.md",
+      "route": "/api/reference/resources/realtime/subresources/calls",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/realtime/subresources/calls.md",
+      "title": "Realtime Calls"
+    },
+    {
+      "path": "docs/en/api/reference/resources/realtime/subresources/calls/methods/create.md",
+      "route": "/api/reference/resources/realtime/subresources/calls/methods/create",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/realtime/subresources/calls/methods/create.md",
+      "title": "Realtime Calls — Create"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses.md",
+      "route": "/api/reference/resources/responses",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses.md",
+      "title": "Responses"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/methods/cancel.md",
+      "route": "/api/reference/resources/responses/methods/cancel",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/methods/cancel.md",
+      "title": "Responses — Cancel"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/methods/compact.md",
+      "route": "/api/reference/resources/responses/methods/compact",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/methods/compact.md",
+      "title": "Responses — Compact"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/methods/create.md",
+      "route": "/api/reference/resources/responses/methods/create",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/methods/create.md",
+      "title": "Responses — Create"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/methods/retrieve.md",
+      "route": "/api/reference/resources/responses/methods/retrieve",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/methods/retrieve.md",
+      "title": "Responses — Retrieve"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/streaming-events.md",
+      "route": "/api/reference/resources/responses/streaming-events",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/streaming-events.md",
+      "title": "Responses streaming events"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/subresources/input_tokens.md",
+      "route": "/api/reference/resources/responses/subresources/input_tokens",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/subresources/input_tokens.md",
+      "title": "Responses Input Tokens"
+    },
+    {
+      "path": "docs/en/api/reference/resources/responses/websocket-events.md",
+      "route": "/api/reference/resources/responses/websocket-events",
+      "sourceUrl": "https://developers.openai.com/api/reference/resources/responses/websocket-events.md",
+      "title": "Responses WebSocket events"
+    },
+    {
+      "path": "docs/en/api/reference/workload-identity-federation.md",
+      "route": "/api/reference/workload-identity-federation",
+      "sourceUrl": "https://developers.openai.com/api/reference/workload-identity-federation.md",
+      "title": "Workload identity token exchange"
+    }
+  ],
+  "removed": []
+}

--- a/scripts/sync-pr-summary.ts
+++ b/scripts/sync-pr-summary.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 export interface SyncDiffSummary {
@@ -13,7 +13,35 @@ export interface SyncDiffSummary {
 
 interface CliOptions {
   baseRef: string;
+  headRef: string;
   outputPath: string;
+  releaseDirectory?: string;
+}
+
+interface SourcePageRecord {
+  localPath: string;
+  sourceUrl: string;
+  title: string;
+}
+
+interface SourceManifest {
+  generatedAt: string;
+  pages: Record<string, SourcePageRecord>;
+}
+
+export interface SyncReleaseEntry {
+  path: string;
+  route: string;
+  sourceUrl: string;
+  title: string;
+}
+
+export interface SyncRelease {
+  added: SyncReleaseEntry[];
+  generatedAt: string;
+  id: string;
+  modified: SyncReleaseEntry[];
+  removed: SyncReleaseEntry[];
 }
 
 function sorted(paths: string[]): string[] {
@@ -91,20 +119,65 @@ export function renderSyncPullRequestBody(summary: SyncDiffSummary): string {
   ].join("\n");
 }
 
+function routeFromSourceUrl(sourceUrl: string): string {
+  return new URL(sourceUrl).pathname.replace(/\.md$/u, "").replace(/\/$/u, "");
+}
+
+function releaseId(generatedAt: string): string {
+  const timestamp = new Date(generatedAt);
+  if (!Number.isFinite(timestamp.valueOf())) {
+    throw new Error(`同步批次时间无效：${generatedAt}`);
+  }
+  return timestamp.toISOString().replace(/[.:]/gu, "-");
+}
+
+export function renderSyncRelease(
+  summary: SyncDiffSummary,
+  manifest: SourceManifest,
+): SyncRelease {
+  const pagesByPath = new Map(
+    Object.values(manifest.pages).map((page) => [page.localPath, page] as const),
+  );
+  const entries = (paths: string[]) => paths
+    .filter((path) => path.startsWith("docs/en/") && path.endsWith(".md"))
+    .map((path) => {
+      const page = pagesByPath.get(path);
+      if (!page) throw new Error(`同步清单缺少文章记录：${path}`);
+      return {
+        path,
+        route: routeFromSourceUrl(page.sourceUrl),
+        sourceUrl: page.sourceUrl,
+        title: page.title,
+      };
+    });
+
+  return {
+    id: releaseId(manifest.generatedAt),
+    generatedAt: manifest.generatedAt,
+    added: entries(summary.added),
+    modified: entries(summary.modified),
+    removed: entries(summary.removed),
+  };
+}
+
 function parseCliOptions(argv: string[]): CliOptions {
   let baseRef: string | undefined;
+  let headRef = "HEAD";
   let outputPath: string | undefined;
+  let releaseDirectory: string | undefined;
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--base-ref") baseRef = argv[++index];
+    else if (argument === "--head-ref") headRef = argv[++index] ?? "HEAD";
     else if (argument === "--output") outputPath = argv[++index];
+    else if (argument === "--release-dir") releaseDirectory = argv[++index];
     else throw new Error(`未知参数：${argument}`);
   }
 
   if (!baseRef) throw new Error("缺少 --base-ref。");
   if (!outputPath) throw new Error("缺少 --output。");
-  return { baseRef, outputPath };
+  return { baseRef, headRef, outputPath, releaseDirectory };
 }
 
 export async function main(argv = process.argv.slice(2)): Promise<void> {
@@ -116,7 +189,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       "--name-status",
       "-z",
       "--no-renames",
-      `${options.baseRef}...HEAD`,
+      `${options.baseRef}...${options.headRef}`,
       "--",
       "docs/en",
     ],
@@ -124,6 +197,20 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   );
   const summary = parseNameStatus(diff);
   await writeFile(options.outputPath, renderSyncPullRequestBody(summary), "utf8");
+  if (options.releaseDirectory) {
+    const manifest = JSON.parse(
+      await readFile(resolve("docs/en/.source-manifest.json"), "utf8"),
+    ) as SourceManifest;
+    const release = renderSyncRelease(summary, manifest);
+    const releaseDirectory = resolve(options.releaseDirectory);
+    await mkdir(releaseDirectory, { recursive: true });
+    const releasePath = resolve(releaseDirectory, `${release.id}.json`);
+    if (basename(releasePath) !== `${release.id}.json`) {
+      throw new Error(`同步批次文件名无效：${release.id}`);
+    }
+    await writeFile(releasePath, `${JSON.stringify(release, null, 2)}\n`, "utf8");
+    console.log(`同步批次记录：${releasePath}`);
+  }
   console.log(
     `同步 PR 摘要：新增=${summary.added.length} 修改=${summary.modified.length} 删除=${summary.removed.length}`,
   );

--- a/scripts/tests/sync-pr-summary.test.ts
+++ b/scripts/tests/sync-pr-summary.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   parseNameStatus,
+  renderSyncRelease,
   renderSyncPullRequestBody,
 } from "../sync-pr-summary.ts";
 
@@ -52,4 +53,43 @@ test("renderSyncPullRequestBody uses Chinese sections and lists every path", () 
   assert.match(body, /`docs\/en\/api\/docs\/changed\.md`/);
   assert.match(body, /## 删除文件（0）\n\n无。/);
   assert.match(body, /仅在 `Quality gate` 通过后合入/);
+});
+
+test("renderSyncRelease keeps article changes and resolves page metadata", () => {
+  const release = renderSyncRelease(
+    {
+      added: ["docs/en/api/docs/new.md", "docs/en/api/docs/llms.txt"],
+      modified: ["docs/en/.source-manifest.json", "docs/en/api/docs/changed.md"],
+      removed: ["docs/en/api/docs/removed.md"],
+    },
+    {
+      generatedAt: "2026-08-27T00:49:10Z",
+      pages: {
+        new: {
+          localPath: "docs/en/api/docs/new.md",
+          sourceUrl: "https://developers.openai.com/api/docs/new.md",
+          title: "New page",
+        },
+        changed: {
+          localPath: "docs/en/api/docs/changed.md",
+          sourceUrl: "https://developers.openai.com/api/docs/changed.md",
+          title: "Changed page",
+        },
+        removed: {
+          localPath: "docs/en/api/docs/removed.md",
+          sourceUrl: "https://developers.openai.com/api/docs/removed.md",
+          title: "Removed page",
+        },
+      },
+    },
+  );
+
+  assert.equal(release.id, "2026-08-27T00-49-10-000Z");
+  assert.deepEqual(release.added.map((entry) => entry.title), ["New page"]);
+  assert.deepEqual(release.modified.map((entry) => entry.route), [
+    "/api/docs/changed",
+  ]);
+  assert.deepEqual(release.removed.map((entry) => entry.title), [
+    "Removed page",
+  ]);
 });

--- a/scripts/tests/translation-planner.test.ts
+++ b/scripts/tests/translation-planner.test.ts
@@ -132,6 +132,7 @@ async function createFixture(): Promise<string> {
       glossaryPath: "scripts/translation/glossary.zh-CN.json",
       priorityPath: "scripts/translation/priority.zh-CN.json",
       promptPath: "scripts/translation/prompt.zh-CN.md",
+      reviewNotesPath: "scripts/translation/review-notes.zh-CN.json",
       provider: {
         apiKeyEnv: "DEEPSEEK_API_KEY",
         id: "deepseek",
@@ -152,6 +153,10 @@ async function createFixture(): Promise<string> {
   await writeFile(
     join(root, "scripts/translation/prompt.zh-CN.md"),
     "translate accurately",
+  );
+  await writeFile(
+    join(root, "scripts/translation/review-notes.zh-CN.json"),
+    JSON.stringify({ pages: {}, schemaVersion: 1 }),
   );
   await writeFile(join(root, SOURCE_PATH), SOURCE_CONTENT);
   await writeSourceManifest(root, [sourcePage()]);
@@ -372,6 +377,7 @@ test("planner requires a versioned config and keeps the source manifest under so
     glossaryPath: "scripts/translation/glossary.zh-CN.json",
     priorityPath: "scripts/translation/priority.zh-CN.json",
     promptPath: "scripts/translation/prompt.zh-CN.md",
+    reviewNotesPath: "scripts/translation/review-notes.zh-CN.json",
     provider: {
       apiKeyEnv: "DEEPSEEK_API_KEY",
       id: "deepseek",

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -20,7 +20,10 @@ import {
   type TranslationProvider,
 } from "@easy-translate/core";
 
-import { loadTranslationWorkspace } from "../translation/planner.ts";
+import {
+  loadTranslationWorkspace,
+  translationPolicySha256ForPage,
+} from "../translation/planner.ts";
 import {
   atomicWriteRepositoryFile,
   createTranslationQualityPolicy,
@@ -69,6 +72,7 @@ async function createFixture(source = DEFAULT_SOURCE): Promise<string> {
       glossaryPath: "scripts/translation/glossary.zh-CN.json",
       priorityPath: "scripts/translation/priority.zh-CN.json",
       promptPath: "scripts/translation/prompt.zh-CN.md",
+      reviewNotesPath: "scripts/translation/review-notes.zh-CN.json",
       provider: {
         apiKeyEnv: "DEEPSEEK_API_KEY",
         id: "deepseek",
@@ -93,6 +97,10 @@ async function createFixture(source = DEFAULT_SOURCE): Promise<string> {
   await writeFile(
     join(root, "scripts/translation/prompt.zh-CN.md"),
     "Translate accurately.",
+  );
+  await writeFile(
+    join(root, "scripts/translation/review-notes.zh-CN.json"),
+    JSON.stringify({ pages: {}, schemaVersion: 1 }),
   );
   return root;
 }
@@ -123,6 +131,55 @@ test("runner simulates one page without writing a target or manifest", async () 
     await assert.rejects(
       readFile(join(root, "docs/zh/.translation-manifest.json")),
       /ENOENT/u,
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("runner injects matching page review notes and records their page policy", async () => {
+  const root = await createFixture();
+  try {
+    const note = "保留此页缩写，并按括号中的释义理解上下文。";
+    await writeFile(
+      join(root, "scripts/translation/review-notes.zh-CN.json"),
+      JSON.stringify({
+        pages: { [SOURCE_URL]: [note] },
+        schemaVersion: 1,
+      }),
+    );
+    const workspace = await loadTranslationWorkspace(root);
+    const seenInstructions: string[] = [];
+    const provider = defineProvider<MarkdownTranslationContext>({
+      async translateBatch(request) {
+        assert.ok(request.instructions);
+        seenInstructions.push(request.instructions);
+        return request.items.map((item) => ({
+          id: item.id,
+          text:
+            item.text === "Hello OpenAI"
+              ? "你好 OpenAI"
+              : item.text === "Request API data."
+                ? "请求 API 数据。"
+                : item.text,
+        }));
+      },
+    });
+    const run = await runTranslationPage(workspace, SOURCE_URL, {
+      commit: false,
+      provider,
+      useCheckpoint: false,
+    });
+
+    assert.ok(seenInstructions.length > 0);
+    assert.ok(
+      seenInstructions.every((instructions) => instructions.includes(note)),
+    );
+    assert.notEqual(run.record.policySha256, workspace.policySha256);
+    assert.equal(
+      translationPolicySha256ForPage(workspace, SECOND_SOURCE_URL),
+      workspace.policySha256,
+      "a page without notes must retain the shared base policy",
     );
   } finally {
     await rm(root, { force: true, recursive: true });
@@ -227,6 +284,45 @@ test("review adopts an intentional target edit and records reviewed status", asy
       refreshed.translationManifest.generatedAt,
       "2026-08-24T13:00:00.000Z",
     );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("review adopts a manual edit together with its new page note policy", async () => {
+  const root = await createFixture();
+  try {
+    const workspace = await loadTranslationWorkspace(root);
+    await runTranslationPage(workspace, SOURCE_URL, {
+      commit: true,
+      provider: translatedProvider(),
+      useCheckpoint: false,
+    });
+    await writeFile(
+      join(root, TARGET_PATH),
+      "# 你好 OpenAI\n\n按页面上下文人工审核后的请求 API 数据。\n",
+    );
+    const note = "此页按特定上下文翻译缩写。";
+    await writeFile(
+      join(root, "scripts/translation/review-notes.zh-CN.json"),
+      JSON.stringify({
+        pages: { [SOURCE_URL]: [note] },
+        schemaVersion: 1,
+      }),
+    );
+
+    const modified = await loadTranslationWorkspace(root);
+    assert.equal(modified.entries[0]?.state, "modified-target");
+    const expectedPolicy = translationPolicySha256ForPage(
+      modified,
+      SOURCE_URL,
+    );
+    await reviewTranslationPage(modified, SOURCE_URL);
+
+    const refreshed = await loadTranslationWorkspace(root);
+    assert.equal(refreshed.entries[0]?.state, "current");
+    assert.equal(refreshed.entries[0]?.record?.policySha256, expectedPolicy);
+    assert.equal(refreshed.entries[0]?.record?.reviewStatus, "reviewed");
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/scripts/translation.config.json
+++ b/scripts/translation.config.json
@@ -2,6 +2,7 @@
   "glossaryPath": "scripts/translation/glossary.zh-CN.json",
   "priorityPath": "scripts/translation/priority.zh-CN.json",
   "promptPath": "scripts/translation/prompt.zh-CN.md",
+  "reviewNotesPath": "scripts/translation/review-notes.zh-CN.json",
   "provider": {
     "apiKeyEnv": "DEEPSEEK_API_KEY",
     "id": "deepseek",

--- a/scripts/translation/planner.ts
+++ b/scripts/translation/planner.ts
@@ -13,6 +13,7 @@ import type {
   TranslationPageRecord,
   TranslationPageState,
   TranslationProviderProfile,
+  TranslationReviewNotes,
   TranslationReviewStatus,
   TranslationStatusReport,
   TranslationWorkspaceSnapshot,
@@ -172,6 +173,7 @@ function parseConfig(raw: unknown): TranslationConfig {
       "priorityPath",
       "promptPath",
       "provider",
+      "reviewNotesPath",
       "schemaVersion",
       "sourceManifestPath",
       "sourceRoot",
@@ -198,6 +200,13 @@ function parseConfig(raw: unknown): TranslationConfig {
       "翻译配置.promptPath",
     ),
     provider: parseProviderProfile(object.provider),
+    reviewNotesPath:
+      object.reviewNotesPath === undefined
+        ? undefined
+        : normalizedRepositoryPath(
+            requiredString(object, "reviewNotesPath", "翻译配置"),
+            "翻译配置.reviewNotesPath",
+          ),
     schemaVersion: 2,
     sourceManifestPath: normalizedRepositoryPath(
       requiredString(object, "sourceManifestPath", "翻译配置"),
@@ -298,6 +307,67 @@ function validateGlossary(raw: unknown): TranslationGlossary {
         .map(([source, target]) => [source, target as string]),
     ),
   };
+}
+
+function validateReviewNotes(raw: unknown): TranslationReviewNotes {
+  const reviewNotes = asObject(raw, "页面级审核备注");
+  assertKnownKeys(reviewNotes, ["pages", "schemaVersion"], "页面级审核备注");
+  if (reviewNotes.schemaVersion !== 1) {
+    throw new Error("页面级审核备注.schemaVersion 必须是 1。");
+  }
+  const pages = asObject(reviewNotes.pages, "页面级审核备注.pages");
+  const normalizedPages: Record<string, string[]> = {};
+  for (const [sourceUrl, rawNotes] of Object.entries(pages)) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(sourceUrl);
+    } catch {
+      throw new Error(`页面级审核备注的 sourceUrl 无效：${sourceUrl}`);
+    }
+    if (
+      parsedUrl.protocol !== "https:" ||
+      parsedUrl.hostname !== "developers.openai.com" ||
+      !parsedUrl.pathname.endsWith(".md") ||
+      parsedUrl.search ||
+      parsedUrl.hash
+    ) {
+      throw new Error(`页面级审核备注仅支持官方 Markdown URL：${sourceUrl}`);
+    }
+    if (
+      !Array.isArray(rawNotes) ||
+      rawNotes.length === 0 ||
+      rawNotes.some(
+        (note) =>
+          typeof note !== "string" ||
+          !note.trim() ||
+          note !== note.trim() ||
+          note.length > 1_000,
+      )
+    ) {
+      throw new Error(`页面级审核备注必须是非空且不超过 1000 字的字符串数组：${sourceUrl}`);
+    }
+    const notes = rawNotes as string[];
+    if (new Set(notes).size !== notes.length) {
+      throw new Error(`页面级审核备注不能重复：${sourceUrl}`);
+    }
+    normalizedPages[sourceUrl] = [...notes];
+  }
+  return {
+    pages: Object.fromEntries(
+      Object.entries(normalizedPages).sort(([left], [right]) =>
+        left.localeCompare(right, "en"),
+      ),
+    ),
+    schemaVersion: 1,
+  };
+}
+
+export function translationPagePolicySha256(
+  basePolicySha256: string,
+  notes: readonly string[],
+): string {
+  if (notes.length === 0) return basePolicySha256;
+  return sha256(JSON.stringify({ basePolicySha256, reviewNotes: notes }));
 }
 
 function parseSourceManifest(raw: unknown): SourcePageSnapshot[] {
@@ -632,6 +702,15 @@ export async function loadTranslationWorkspace(
     throw new Error("中文术语表不是有效 JSON。", { cause: error });
   }
   const glossary = validateGlossary(parsedGlossary);
+  const reviewNotes = config.reviewNotesPath
+    ? validateReviewNotes(
+        await readJson(
+          root,
+          repositoryPath(root, config.reviewNotesPath),
+          "页面级审核备注",
+        ),
+      )
+    : { pages: {}, schemaVersion: 1 } satisfies TranslationReviewNotes;
   const policySha256 = sha256(
     JSON.stringify({
       adapter: MARKDOWN_ADAPTER_POLICY_VERSION,
@@ -643,6 +722,11 @@ export async function loadTranslationWorkspace(
   );
 
   const sourceByUrl = new Map(sourcePages.map((page) => [page.sourceUrl, page]));
+  for (const sourceUrl of Object.keys(reviewNotes.pages)) {
+    if (!sourceByUrl.has(sourceUrl)) {
+      throw new Error(`页面级审核备注没有对应的英文页面：${sourceUrl}`);
+    }
+  }
   const sourcePathOwners = new Map<string, string>();
   for (const source of sourcePages) {
     const normalizedSourcePath = pathInsideRoot(
@@ -703,7 +787,10 @@ export async function loadTranslationWorkspace(
       record,
       source,
       state: classifyTranslationPage({
-        policySha256,
+        policySha256: translationPagePolicySha256(
+          policySha256,
+          reviewNotes.pages[source.sourceUrl] ?? [],
+        ),
         record,
         source,
         targetSha256,
@@ -727,9 +814,20 @@ export async function loadTranslationWorkspace(
     policySha256,
     prompt,
     repositoryRoot: root,
+    reviewNotes,
     targetLanguage: config.targetLanguage,
     translationManifest,
   };
+}
+
+export function translationPolicySha256ForPage(
+  workspace: TranslationWorkspaceSnapshot,
+  sourceUrl: string,
+): string {
+  return translationPagePolicySha256(
+    workspace.policySha256,
+    workspace.reviewNotes.pages[sourceUrl] ?? [],
+  );
 }
 
 export async function buildTranslationStatusReport(

--- a/scripts/translation/review-notes.zh-CN.json
+++ b/scripts/translation/review-notes.zh-CN.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "pages": {
+    "https://developers.openai.com/api/docs/actions/getting-started.md": [
+      "原文中的“NSW (National Weather Service)”缩写与括号释义不一致；不要将 NSW 扩写为“新南威尔士州”，保留缩写 NSW，并按括号中的 National Weather Service 理解上下文。"
+    ]
+  }
+}

--- a/scripts/translation/runner.ts
+++ b/scripts/translation/runner.ts
@@ -39,6 +39,7 @@ import {
 import {
   loadTranslationWorkspace,
   readTranslationWorkspaceFile,
+  translationPolicySha256ForPage,
 } from "./planner.ts";
 import type {
   TranslationGlossary,
@@ -427,12 +428,21 @@ export function createTranslationQualityPolicy(
   };
 }
 
-function instructionsForWorkspace(workspace: TranslationWorkspaceSnapshot): string {
-  return `${workspace.prompt.trim()}\n\n术语表：\n${JSON.stringify(
+function instructionsForWorkspace(
+  workspace: TranslationWorkspaceSnapshot,
+  sourceUrl: string,
+): string {
+  const base = `${workspace.prompt.trim()}\n\n术语表：\n${JSON.stringify(
     workspace.glossary,
     null,
     2,
   )}`;
+  const notes = workspace.reviewNotes.pages[sourceUrl] ?? [];
+  return notes.length === 0
+    ? base
+    : `${base}\n\n本页人工审核备注（仅适用于当前页面）：\n${notes
+        .map((note) => `- ${note}`)
+        .join("\n")}`;
 }
 
 function stableManifest(
@@ -470,7 +480,8 @@ export async function commitTranslationPage(
     entry.source.sha256 !== record.sourceSha256 ||
     entry.source.sourcePath !== record.sourcePath ||
     entry.targetPath !== record.targetPath ||
-    fresh.policySha256 !== record.policySha256
+    translationPolicySha256ForPage(fresh, record.sourceUrl) !==
+      record.policySha256
   ) {
     throw new Error(`提交前翻译工作区已变化，拒绝写入：${record.sourceUrl}`);
   }
@@ -511,12 +522,10 @@ export async function reviewTranslationPage(
   if (entry.state !== "current" && entry.state !== "modified-target") {
     throw new Error(`页面状态 ${entry.state} 不允许登记人工审核：${sourceUrl}`);
   }
-  if (
-    entry.record.sourceSha256 !== entry.source.sha256 ||
-    entry.record.policySha256 !== fresh.policySha256
-  ) {
-    throw new Error(`英文来源或翻译策略已变化，拒绝登记人工审核：${sourceUrl}`);
+  if (entry.record.sourceSha256 !== entry.source.sha256) {
+    throw new Error(`英文来源已变化，拒绝登记人工审核：${sourceUrl}`);
   }
+  const policySha256 = translationPolicySha256ForPage(fresh, sourceUrl);
   const target = await readTranslationWorkspaceFile(
     fresh,
     entry.targetPath,
@@ -547,6 +556,7 @@ export async function reviewTranslationPage(
   const targetSha256 = sha256(target);
   const record: TranslationPageRecord = {
     ...entry.record,
+    policySha256,
     reviewStatus: "reviewed",
     targetSha256,
   };
@@ -594,9 +604,16 @@ export async function runTranslationPage(
     id: entry.source.sourceUrl,
     sourceHash: entry.source.sha256,
   });
-  const path = checkpointPath(entry.source.sourceUrl, workspace.policySha256);
+  const pagePolicySha256 = translationPolicySha256ForPage(
+    workspace,
+    entry.source.sourceUrl,
+  );
+  const path = checkpointPath(entry.source.sourceUrl, pagePolicySha256);
   const useCheckpoint = options.useCheckpoint ?? true;
-  const instructions = instructionsForWorkspace(workspace);
+  const instructions = instructionsForWorkspace(
+    workspace,
+    entry.source.sourceUrl,
+  );
   let lastReportedRetry: TranslationRetryEvent | undefined;
   const result = await translatePlan(prepared.plan, {
     batchSize: options.batchSize ?? 20,
@@ -640,7 +657,7 @@ export async function runTranslationPage(
   );
   const translatedAt = (options.now ?? (() => new Date()))().toISOString();
   const record: TranslationPageRecord = {
-    policySha256: workspace.policySha256,
+    policySha256: pagePolicySha256,
     reviewStatus: "machine",
     sourcePath: entry.source.sourcePath,
     sourceSha256: entry.source.sha256,

--- a/scripts/translation/types.ts
+++ b/scripts/translation/types.ts
@@ -6,6 +6,7 @@ export interface TranslationConfig {
   glossaryPath: string;
   priorityPath: string;
   promptPath: string;
+  reviewNotesPath?: string | undefined;
   provider: TranslationProviderProfile;
   schemaVersion: 2;
   sourceManifestPath: string;
@@ -25,6 +26,11 @@ export interface TranslationGlossary {
   preserve: string[];
   schemaVersion: 1;
   terms: Record<string, string>;
+}
+
+export interface TranslationReviewNotes {
+  pages: Record<string, string[]>;
+  schemaVersion: 1;
 }
 
 export interface SourcePageSnapshot {
@@ -82,5 +88,6 @@ export interface TranslationWorkspaceSnapshot extends TranslationStatusReport {
   glossary: TranslationGlossary;
   prompt: string;
   repositoryRoot: string;
+  reviewNotes: TranslationReviewNotes;
   translationManifest: TranslationManifest;
 }


### PR DESCRIPTION
## 概要

- 改进文档与 API 参考侧边栏的展开收起，并将外部文档合集移出普通文章导航
- 固定文档页标题、更新时间、原文说明和正文顺序，避免正文首段被重复提取
- 首页增加同步批次与文章级新增、修改、删除详情，并接入“找到我”和网站分析
- 新增页面级人工审核备注，按 source URL 注入翻译请求，并只让对应页面的翻译策略失效

## 验证

- `pnpm test`（94 项）
- `pnpm typecheck`
- `pnpm --dir apps/web test`（15 项）
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/web build`（855 个静态页面）