### PR TITLE
[AI] feat: 支持按环境选择翻译模型供应商

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -27,6 +27,10 @@ jobs:
   translate:
     if: github.ref == 'refs/heads/main'
     environment: translation-production
+    env:
+      DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+      MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}
+      TRANSLATION_PROVIDER: ${{ vars.TRANSLATION_PROVIDER }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -88,16 +92,12 @@ jobs:
           pnpm test
           pnpm translate:check
 
-      - name: Translate up to ten budgeted pages with DeepSeek
+      - name: Translate up to ten budgeted pages
         if: steps.open-pr.outputs.exists != 'true'
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-        run: |
-          if [[ -z "$DEEPSEEK_API_KEY" ]]; then
-            echo "DEEPSEEK_API_KEY is not configured for translation-production." >&2
-            exit 1
-          fi
-          pnpm translate:auto -- --limit 10
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+        run: pnpm translate:auto -- --limit 10
 
       - name: Publish the translation branch
         if: steps.open-pr.outputs.exists != 'true'
@@ -110,7 +110,7 @@ jobs:
           fi
 
           git add docs/zh
-          git commit -m "docs: 自动更新 OpenAI 中文翻译"
+          git commit -m "[AI] docs: 自动更新 OpenAI 中文翻译"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
           if git show-ref --verify --quiet "refs/remotes/origin/$TRANSLATION_BRANCH"; then
@@ -151,7 +151,7 @@ jobs:
             const body = [
               "## 自动中文翻译",
               "",
-              "本 PR 由受信任的 `main` 工作流使用 DeepSeek 自动生成，每次最多处理十篇受预算约束的页面。",
+              "本 PR 由受信任的 `main` 工作流使用环境配置的大模型供应商自动生成，每次最多处理十篇受预算约束的页面。",
               "",
               "### 文件",
               "",

--- a/README.md
+++ b/README.md
@@ -66,7 +66,19 @@ pnpm translate:simulate -- --match guides/agents/quickstart.md --limit 1
 
 GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行测试并同步英文 Markdown。只有 `docs/en/` 相对 `main` 实际发生变化时，机器人分支 `automation/sync-openai-docs` 才会创建或更新 PR；机器人不会直接写入 `main`。自动 PR 仍须在维护者批准工作流运行后通过 `Quality gate`，并由维护者审核合并。
 
-中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，并从 **Settings → Environments → translation-production** 读取运行配置：在 **Environment secrets** 中配置 `MINIMAX_API_KEY` 或 `DEEPSEEK_API_KEY`；只有一个 Key 时自动选择对应供应商，同时存在两个 Key 时必须在 **Environment variables** 中设置 `TRANSLATION_PROVIDER` 为 `minimax-cn`、`minimax` 或 `deepseek`。模型通过同处的 `MINIMAX_MODEL` 或 `DEEPSEEK_MODEL` 切换；未配置时分别使用 `MiniMax-M3` 或 `deepseek-chat`，无需修改仓库或创建 PR。运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
+中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，并从 **Settings → Environments → translation-production** 读取运行配置。
+
+`TRANSLATION_PROVIDER` 支持以下键名：
+
+| 键名 | 服务 | API 地址 | Environment secret | 模型变量 | 默认模型 |
+| --- | --- | --- | --- | --- | --- |
+| `deepseek` | DeepSeek | `https://api.deepseek.com/v1` | `DEEPSEEK_API_KEY` | `DEEPSEEK_MODEL` | `deepseek-chat` |
+| `minimax` | MiniMax 国际站 | `https://api.minimax.io/v1` | `MINIMAX_API_KEY` | `MINIMAX_MODEL` | `MiniMax-M3` |
+| `minimax-cn` | MiniMax 国内站（含国内 Token Plan） | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` | `MINIMAX_MODEL` | `MiniMax-M3` |
+
+在 **Environment secrets** 中配置 `MINIMAX_API_KEY` 或 `DEEPSEEK_API_KEY`。只有一个 Key 时会自动选择对应供应商；仅有 MiniMax Key 时默认选择国内站 `minimax-cn`。同时存在两个 Key 时必须在 **Environment variables** 中设置 `TRANSLATION_PROVIDER`，值只能是上表中的键名。模型可通过同处的 `MINIMAX_MODEL` 或 `DEEPSEEK_MODEL` 切换，无需修改仓库或创建 PR。MiniMax 国内站 Plan 应使用 `minimax-cn`；国内站与国际站的 Key 和额度按各自接口生效，不应混用。
+
+运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
 
 仓库必须在 **Settings → Actions → General → Workflow permissions** 中启用 **Allow GitHub Actions to create and approve pull requests**。`main` 的 Ruleset 可以因此保持空 bypass，并要求所有更新通过 PR 和 `Quality gate`。PR 标题必须以 `[AI] ` 或 `[Human] ` 标明来源，其中 `codex/` 与 `automation/` 分支强制使用 `[AI] `。
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pnpm translate:simulate -- --match guides/agents/quickstart.md --limit 1
 
 GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行测试并同步英文 Markdown。只有 `docs/en/` 相对 `main` 实际发生变化时，机器人分支 `automation/sync-openai-docs` 才会创建或更新 PR；机器人不会直接写入 `main`。自动 PR 仍须在维护者批准工作流运行后通过 `Quality gate`，并由维护者审核合并。
 
-中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，从 `translation-production` 环境读取 `DEEPSEEK_API_KEY`，每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
+中文翻译 Action 在英文变更合入 `main` 后立即运行，并每天北京时间 01:00 补充执行。它只检出受信任的 `main`，并从 **Settings → Environments → translation-production** 读取运行配置：在 **Environment secrets** 中配置 `MINIMAX_API_KEY` 或 `DEEPSEEK_API_KEY`；只有一个 Key 时自动选择对应供应商，同时存在两个 Key 时必须在 **Environment variables** 中设置 `TRANSLATION_PROVIDER` 为 `minimax-cn`、`minimax` 或 `deepseek`。模型通过同处的 `MINIMAX_MODEL` 或 `DEEPSEEK_MODEL` 切换；未配置时分别使用 `MiniMax-M3` 或 `deepseek-chat`，无需修改仓库或创建 PR。运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
 
 仓库必须在 **Settings → Actions → General → Workflow permissions** 中启用 **Allow GitHub Actions to create and approve pull requests**。`main` 的 Ruleset 可以因此保持空 bypass，并要求所有更新通过 PR 和 `Quality gate`。PR 标题必须以 `[AI] ` 或 `[Human] ` 标明来源，其中 `codex/` 与 `automation/` 分支强制使用 `[AI] `。
 

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -6,7 +6,7 @@
 
 本仓库负责 Markdown 结构保护、英文/中文路径映射、术语与提示词、翻译 manifest、增量选择和文档级质量门。批处理、并发、Provider 输出校验、重试、checkpoint、进度和取消复用已发布的 `@easy-translate/core`；OpenAI 与兼容接口复用 `@easy-translate/providers`。本仓库不复制 Provider 或通用翻译引擎。
 
-当前实现提供离线的 `translate:status`、`translate:check`、`translate:plan`、Markdown adapter 和单篇 `translate:simulate`；另提供严格限定单篇的 `translate:run`，以及供受信任远端 workflow 使用的受预算约束批量 `translate:auto`，两者通过 `@easy-translate/providers` 接入 DeepSeek。simulate 不调用模型、不读取 API key，也不写入 `docs/zh`。
+当前实现提供离线的 `translate:status`、`translate:check`、`translate:plan`、Markdown adapter 和单篇 `translate:simulate`；另提供严格限定单篇的 `translate:run`，以及供受信任远端 workflow 使用的受预算约束批量 `translate:auto`，两者通过 `@easy-translate/providers` 接入配置指定的 DeepSeek 或 MiniMax。simulate 不调用模型、不读取 API key，也不写入 `docs/zh`。
 
 ## 目录与持久化契约
 
@@ -82,7 +82,7 @@ render 会安全移除模型偶发添加在译文单元首尾的空白，同时�
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 
-真实 profile 固定为 `deepseek` / `deepseek-chat`，key 只从 `DEEPSEEK_API_KEY` 注入；`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配包裹为批次内唯一的成对保护标记，标记内部保留可见原词；响应后无论模型复制标记、只去掉标记外壳、改写成对标记内的内容，还是因中文语序把完整标记移动到相邻翻译单元，都会在整个批次范围恢复为原词。恢复后会按最长匹配核对批次级保留词数量，残留、被破坏、遗漏或额外增加的保护内容会被质量错误拒绝。如果模型在移动保留词后省略了只含保留词和标点的原碎片 ID，Provider 只会在该碎片仍有非空标点时补回标点以满足响应契约；普通自然语言缺项继续拒绝。指定译法也使用独立的成对标记，返回后确定性替换为配置的中文目标词，并按完整单词或短语匹配；已整体保留的产品名优先排除，HTTP 语境的 `user agent(s)` / `user-agent(s)` 也不套用 AI `agent(s) → 智能体` 规则。质量策略会再次复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制保留词或指定译法，因为中文语序可能把它们移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
+真实 profile 支持 `deepseek`、`minimax` 和 `minimax-cn`。运行环境只有一个 `DEEPSEEK_API_KEY` 或 `MINIMAX_API_KEY` 时自动选择对应供应商；两者同时存在时拒绝猜测，必须用 `TRANSLATION_PROVIDER` 显式选择。`DEEPSEEK_MODEL` 与 `MINIMAX_MODEL` 分别覆盖各自默认模型，避免切换供应商时交叉复用错误的模型 ID。当前配置的无环境变量回退值为国内 Token Plan 的 `minimax-cn` / `MiniMax-M3`。解析后的实际 provider/model 会进入策略 SHA，因此通过 GitHub Environment Variables 切换仍会正确使旧策略译文失效。MiniMax 请求会分离推理内容，M3 翻译请求还会关闭思考，确保严格 JSON 响应只包含最终译文。`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配包裹为批次内唯一的成对保护标记，标记内部保留可见原词；响应后无论模型复制标记、只去掉标记外壳、改写成对标记内的内容，还是因中文语序把完整标记移动到相邻翻译单元，都会在整个批次范围恢复为原词。恢复后会按最长匹配核对批次级保留词数量，残留、被破坏、遗漏或额外增加的保护内容会被质量错误拒绝。如果模型在移动保留词后省略了只含保留词和标点的原碎片 ID，Provider 只会在该碎片仍有非空标点时补回标点以满足响应契约；普通自然语言缺项继续拒绝。指定译法也使用独立的成对标记，返回后确定性替换为配置的中文目标词，并按完整单词或短语匹配；已整体保留的产品名优先排除，HTTP 语境的 `user agent(s)` / `user-agent(s)` 也不套用 AI `agent(s) → 智能体` 规则。质量策略会再次复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制保留词或指定译法，因为中文语序可能把它们移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
 
 ## 分阶段交付
 

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -82,7 +82,15 @@ render 会安全移除模型偶发添加在译文单元首尾的空白，同时�
 
 Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` 或 `missing-target` 的单篇页面。checkpoint 位于 Git 忽略的 `.cache/translation-checkpoints/`；提交前重新加载工作区并再次验证状态、源 SHA、策略 SHA 和目标路径。写入顺序固定为译文后 manifest，因此异常中断会转化为可检测的阻塞状态，而不会产生虚假的 current 记录。
 
-真实 profile 支持 `deepseek`、`minimax` 和 `minimax-cn`。运行环境只有一个 `DEEPSEEK_API_KEY` 或 `MINIMAX_API_KEY` 时自动选择对应供应商；两者同时存在时拒绝猜测，必须用 `TRANSLATION_PROVIDER` 显式选择。`DEEPSEEK_MODEL` 与 `MINIMAX_MODEL` 分别覆盖各自默认模型，避免切换供应商时交叉复用错误的模型 ID。当前配置的无环境变量回退值为国内 Token Plan 的 `minimax-cn` / `MiniMax-M3`。解析后的实际 provider/model 会进入策略 SHA，因此通过 GitHub Environment Variables 切换仍会正确使旧策略译文失效。MiniMax 请求会分离推理内容，M3 翻译请求还会关闭思考，确保严格 JSON 响应只包含最终译文。`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配包裹为批次内唯一的成对保护标记，标记内部保留可见原词；响应后无论模型复制标记、只去掉标记外壳、改写成对标记内的内容，还是因中文语序把完整标记移动到相邻翻译单元，都会在整个批次范围恢复为原词。恢复后会按最长匹配核对批次级保留词数量，残留、被破坏、遗漏或额外增加的保护内容会被质量错误拒绝。如果模型在移动保留词后省略了只含保留词和标点的原碎片 ID，Provider 只会在该碎片仍有非空标点时补回标点以满足响应契约；普通自然语言缺项继续拒绝。指定译法也使用独立的成对标记，返回后确定性替换为配置的中文目标词，并按完整单词或短语匹配；已整体保留的产品名优先排除，HTTP 语境的 `user agent(s)` / `user-agent(s)` 也不套用 AI `agent(s) → 智能体` 规则。质量策略会再次复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制保留词或指定译法，因为中文语序可能把它们移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
+真实 profile 的 `TRANSLATION_PROVIDER` 键名及环境映射如下：
+
+| 键名 | Provider 预设 | API 地址 | Key 环境变量 | 模型环境变量 | 默认模型 |
+| --- | --- | --- | --- | --- | --- |
+| `deepseek` | DeepSeek | `https://api.deepseek.com/v1` | `DEEPSEEK_API_KEY` | `DEEPSEEK_MODEL` | `deepseek-chat` |
+| `minimax` | MiniMax 国际站 | `https://api.minimax.io/v1` | `MINIMAX_API_KEY` | `MINIMAX_MODEL` | `MiniMax-M3` |
+| `minimax-cn` | MiniMax 国内站 | `https://api.minimaxi.com/v1` | `MINIMAX_API_KEY` | `MINIMAX_MODEL` | `MiniMax-M3` |
+
+运行环境只有一个 `DEEPSEEK_API_KEY` 或 `MINIMAX_API_KEY` 时自动选择对应供应商；仅有 MiniMax Key 时按当前 profile 默认选择国内站 `minimax-cn`。两者同时存在时拒绝猜测，必须用 `TRANSLATION_PROVIDER` 显式选择上表中的键名。国内 Token Plan 使用 `minimax-cn`，国际站账号使用 `minimax`，两站的 Key 和额度不应混用。`DEEPSEEK_MODEL` 与 `MINIMAX_MODEL` 分别覆盖各自默认模型，避免切换供应商时交叉复用错误的模型 ID。当前配置的无环境变量回退值为国内 Token Plan 的 `minimax-cn` / `MiniMax-M3`。解析后的实际 provider/model 会进入策略 SHA，因此通过 GitHub Environment Variables 切换仍会正确使旧策略译文失效。MiniMax 请求会分离推理内容，M3 翻译请求还会关闭思考，确保严格 JSON 响应只包含最终译文。`translate:run` 自动加载仓库根目录下被 Git 忽略的 `.env`，现有进程环境优先。术语表的 `preserve` 项在 Provider 请求前按最长匹配包裹为批次内唯一的成对保护标记，标记内部保留可见原词；响应后无论模型复制标记、只去掉标记外壳、改写成对标记内的内容，还是因中文语序把完整标记移动到相邻翻译单元，都会在整个批次范围恢复为原词。恢复后会按最长匹配核对批次级保留词数量，残留、被破坏、遗漏或额外增加的保护内容会被质量错误拒绝。如果模型在移动保留词后省略了只含保留词和标点的原碎片 ID，Provider 只会在该碎片仍有非空标点时补回标点以满足响应契约；普通自然语言缺项继续拒绝。指定译法也使用独立的成对标记，返回后确定性替换为配置的中文目标词，并按完整单词或短语匹配；已整体保留的产品名优先排除，HTTP 语境的 `user agent(s)` / `user-agent(s)` 也不套用 AI `agent(s) → 智能体` 规则。质量策略会再次复核术语与占位符，但当同一 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，不再对单个片段强制保留词或指定译法，因为中文语序可能把它们移动到相邻片段；术语表仍会随完整批次发送给模型。该命令必须提供 `--match` 与 `--limit 1`；默认调用模型但不写 `docs/zh` 或 manifest（可能更新 Git 忽略的 checkpoint），只有显式 `--commit` 才原子写入译文与 manifest。API key 不进入配置、策略哈希、日志、checkpoint 或 manifest；provider/model 变更会产生新的策略 SHA 和 checkpoint 路径。
 
 ## 分阶段交付
 

--- a/scripts/tests/translation-planner.test.ts
+++ b/scripts/tests/translation-planner.test.ts
@@ -22,7 +22,10 @@ import {
 import {
   buildTranslationStatusReport,
   classifyTranslationPage,
+  loadTranslationWorkspace,
   mirroredTranslationPath,
+  translationPagePolicySha256,
+  translationPolicySha256ForPage,
 } from "../translation/planner.ts";
 import type {
   SourcePageSnapshot,
@@ -512,6 +515,156 @@ test("planner includes the non-sensitive provider profile in policy identity", a
     );
     const changed = await buildTranslationStatusReport(root);
     assert.notEqual(changed.policySha256, first.policySha256);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("page review notes invalidate only the matching page policy", async () => {
+  const root = await createFixture();
+  try {
+    await writeTarget(root);
+    const initial = await loadTranslationWorkspace(root);
+    await writeTranslationManifest(root, {
+      [SOURCE_URL]: translationRecord({ policySha256: initial.policySha256 }),
+    });
+    assert.equal(
+      (await loadTranslationWorkspace(root)).entries[0]?.state,
+      "current",
+    );
+
+    const note = "保留此页缩写，并按括号中的释义理解上下文。";
+    await writeFile(
+      join(root, "scripts/translation/review-notes.zh-CN.json"),
+      JSON.stringify({
+        pages: { [SOURCE_URL]: [note] },
+        schemaVersion: 1,
+      }),
+    );
+    const changed = await loadTranslationWorkspace(root);
+    assert.equal(changed.policySha256, initial.policySha256);
+    assert.equal(changed.entries[0]?.state, "stale-policy");
+    assert.notEqual(
+      translationPolicySha256ForPage(changed, SOURCE_URL),
+      changed.policySha256,
+    );
+    assert.equal(
+      translationPagePolicySha256(changed.policySha256, []),
+      changed.policySha256,
+    );
+
+    await writeFile(
+      join(root, "scripts/translation/review-notes.zh-CN.json"),
+      JSON.stringify({
+        pages: {
+          "https://developers.openai.com/api/docs/missing.md": [note],
+        },
+        schemaVersion: 1,
+      }),
+    );
+    await assert.rejects(
+      loadTranslationWorkspace(root),
+      /没有对应的英文页面/u,
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("planner accepts a MiniMax profile and rejects a mismatched key variable", async () => {
+  const root = await createFixture();
+  try {
+    const configPath = join(root, "scripts/translation.config.json");
+    const original = JSON.parse(await readFile(configPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        ...original,
+        provider: {
+          apiKeyEnv: "MINIMAX_API_KEY",
+          id: "minimax-cn",
+          model: "MiniMax-M3",
+          modelEnv: "MINIMAX_MODEL",
+          providerEnv: "TRANSLATION_PROVIDER",
+        },
+      }),
+    );
+    const defaultWorkspace = await loadTranslationWorkspace(root, undefined, {});
+    assert.deepEqual(defaultWorkspace.config.provider, {
+      apiKeyEnv: "MINIMAX_API_KEY",
+      id: "minimax-cn",
+      model: "MiniMax-M3",
+      modelEnv: "MINIMAX_MODEL",
+      providerEnv: "TRANSLATION_PROVIDER",
+    });
+    const overriddenWorkspace = await loadTranslationWorkspace(
+      root,
+      undefined,
+      { MINIMAX_MODEL: "MiniMax-M2.7" },
+    );
+    assert.deepEqual(overriddenWorkspace.config.provider, {
+      apiKeyEnv: "MINIMAX_API_KEY",
+      id: "minimax-cn",
+      model: "MiniMax-M2.7",
+      modelEnv: "MINIMAX_MODEL",
+      providerEnv: "TRANSLATION_PROVIDER",
+    });
+    assert.notEqual(
+      overriddenWorkspace.policySha256,
+      defaultWorkspace.policySha256,
+    );
+    const autoSelectedDeepSeek = await loadTranslationWorkspace(
+      root,
+      undefined,
+      { DEEPSEEK_API_KEY: "deepseek-secret" },
+    );
+    assert.deepEqual(autoSelectedDeepSeek.config.provider, {
+      apiKeyEnv: "DEEPSEEK_API_KEY",
+      id: "deepseek",
+      model: "deepseek-chat",
+      modelEnv: "DEEPSEEK_MODEL",
+      providerEnv: "TRANSLATION_PROVIDER",
+    });
+    await assert.rejects(
+      loadTranslationWorkspace(root, undefined, {
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        MINIMAX_API_KEY: "minimax-secret",
+      }),
+      /检测到多个翻译 API Key.*TRANSLATION_PROVIDER/u,
+    );
+    const explicitlySelectedMiniMax = await loadTranslationWorkspace(
+      root,
+      undefined,
+      {
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        MINIMAX_API_KEY: "minimax-secret",
+        MINIMAX_MODEL: "MiniMax-M3",
+        TRANSLATION_PROVIDER: "minimax-cn",
+      },
+    );
+    assert.equal(explicitlySelectedMiniMax.config.provider.id, "minimax-cn");
+    assert.equal(explicitlySelectedMiniMax.config.provider.model, "MiniMax-M3");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        ...original,
+        provider: {
+          apiKeyEnv: "DEEPSEEK_API_KEY",
+          id: "minimax-cn",
+          model: "MiniMax-M3",
+          modelEnv: "MINIMAX_MODEL",
+          providerEnv: "TRANSLATION_PROVIDER",
+        },
+      }),
+    );
+    await assert.rejects(
+      loadTranslationWorkspace(root),
+      /必须与 minimax-cn 匹配为 MINIMAX_API_KEY/u,
+    );
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/scripts/tests/translation-provider.test.ts
+++ b/scripts/tests/translation-provider.test.ts
@@ -23,6 +23,16 @@ const PROFILE: TranslationProviderProfile = {
   apiKeyEnv: "DEEPSEEK_API_KEY",
   id: "deepseek",
   model: "deepseek-chat",
+  modelEnv: "DEEPSEEK_MODEL",
+  providerEnv: "TRANSLATION_PROVIDER",
+};
+
+const MINIMAX_PROFILE: TranslationProviderProfile = {
+  apiKeyEnv: "MINIMAX_API_KEY",
+  id: "minimax-cn",
+  model: "MiniMax-M3",
+  modelEnv: "MINIMAX_MODEL",
+  providerEnv: "TRANSLATION_PROVIDER",
 };
 
 test("configured DeepSeek provider requires its key without exposing credentials", () => {
@@ -34,6 +44,75 @@ test("configured DeepSeek provider requires its key without exposing credentials
   assert.doesNotThrow(() =>
     createConfiguredProvider(PROFILE, { DEEPSEEK_API_KEY: secret }),
   );
+  assert.throws(
+    () =>
+      createConfiguredProvider(PROFILE, {
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        MINIMAX_API_KEY: "minimax-secret",
+      }),
+    /检测到多个翻译 API Key.*TRANSLATION_PROVIDER/u,
+  );
+  assert.doesNotThrow(() =>
+    createConfiguredProvider(PROFILE, {
+      DEEPSEEK_API_KEY: "deepseek-secret",
+      MINIMAX_API_KEY: "minimax-secret",
+      TRANSLATION_PROVIDER: "deepseek",
+    }),
+  );
+});
+
+test("configured MiniMax CN provider uses the selected model and separates reasoning", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestedUrl = "";
+  let authorization = "";
+  let requestBody: Record<string, unknown> = {};
+  globalThis.fetch = (async (input, init) => {
+    requestedUrl = String(input);
+    authorization = new Headers(init?.headers).get("authorization") ?? "";
+    requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return Response.json({
+      choices: [
+        {
+          message: {
+            content:
+              '{"translations":[{"id":"greeting","text":"你好"}]}',
+          },
+        },
+      ],
+    });
+  }) as typeof fetch;
+
+  try {
+    const provider = createConfiguredProvider(MINIMAX_PROFILE, {
+      MINIMAX_API_KEY: "minimax-secret",
+    });
+    const result = await provider.translateBatch({
+      items: [
+        {
+          context: {
+            block: "body",
+            end: 5,
+            fragmented: false,
+            kind: "text",
+            policyVersion: "markdown-source-ranges-v4",
+            start: 0,
+          },
+          id: "greeting",
+          text: "Hello",
+        },
+      ],
+      targetLanguage: "zh-CN",
+    });
+
+    assert.equal(requestedUrl, "https://api.minimaxi.com/v1/chat/completions");
+    assert.equal(authorization, "Bearer minimax-secret");
+    assert.equal(requestBody.model, "MiniMax-M3");
+    assert.equal(requestBody.reasoning_split, true);
+    assert.deepEqual(requestBody.thinking, { type: "disabled" });
+    assert.deepEqual(result, [{ id: "greeting", text: "你好" }]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("fragmented article provider completes omitted Chinese article fragments", async () => {

--- a/scripts/translation.config.json
+++ b/scripts/translation.config.json
@@ -4,9 +4,11 @@
   "promptPath": "scripts/translation/prompt.zh-CN.md",
   "reviewNotesPath": "scripts/translation/review-notes.zh-CN.json",
   "provider": {
-    "apiKeyEnv": "DEEPSEEK_API_KEY",
-    "id": "deepseek",
-    "model": "deepseek-chat"
+    "apiKeyEnv": "MINIMAX_API_KEY",
+    "id": "minimax-cn",
+    "model": "MiniMax-M3",
+    "modelEnv": "MINIMAX_MODEL",
+    "providerEnv": "TRANSLATION_PROVIDER"
   },
   "schemaVersion": 2,
   "sourceManifestPath": "docs/en/.source-manifest.json",

--- a/scripts/translation/planner.ts
+++ b/scripts/translation/planner.ts
@@ -18,6 +18,7 @@ import type {
   TranslationStatusReport,
   TranslationWorkspaceSnapshot,
 } from "./types.ts";
+import { resolveTranslationProviderProfile } from "./provider-profile.ts";
 
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 export const MARKDOWN_ADAPTER_POLICY_VERSION = "markdown-source-ranges-v4";
@@ -164,7 +165,10 @@ export function mirroredTranslationPath(
   return posix.join(normalizedTargetRoot, relativePath);
 }
 
-function parseConfig(raw: unknown): TranslationConfig {
+function parseConfig(
+  raw: unknown,
+  environment: NodeJS.ProcessEnv,
+): TranslationConfig {
   const object = asObject(raw, "翻译配置");
   assertKnownKeys(
     object,
@@ -199,7 +203,7 @@ function parseConfig(raw: unknown): TranslationConfig {
       requiredString(object, "promptPath", "翻译配置"),
       "翻译配置.promptPath",
     ),
-    provider: parseProviderProfile(object.provider),
+    provider: parseProviderProfile(object.provider, environment),
     reviewNotesPath:
       object.reviewNotesPath === undefined
         ? undefined
@@ -247,20 +251,81 @@ function parseConfig(raw: unknown): TranslationConfig {
   return config;
 }
 
-function parseProviderProfile(raw: unknown): TranslationProviderProfile {
+function parseProviderProfile(
+  raw: unknown,
+  environment: NodeJS.ProcessEnv,
+): TranslationProviderProfile {
   const object = asObject(raw, "翻译配置.provider");
-  assertKnownKeys(object, ["apiKeyEnv", "id", "model"], "翻译配置.provider");
-  if (object.id !== "deepseek") {
-    throw new Error("翻译配置.provider.id 目前必须是 deepseek。");
+  assertKnownKeys(
+    object,
+    ["apiKeyEnv", "id", "model", "modelEnv", "providerEnv"],
+    "翻译配置.provider",
+  );
+  const id = requiredString(object, "id", "翻译配置.provider");
+  const model = requiredString(object, "model", "翻译配置.provider");
+  if (
+    object.providerEnv !== undefined &&
+    object.providerEnv !== "TRANSLATION_PROVIDER"
+  ) {
+    throw new Error(
+      "翻译配置.provider.providerEnv 目前必须是 TRANSLATION_PROVIDER。",
+    );
   }
-  if (object.apiKeyEnv !== "DEEPSEEK_API_KEY") {
-    throw new Error("翻译配置.provider.apiKeyEnv 必须是 DEEPSEEK_API_KEY。");
+  const providerEnv =
+    object.providerEnv === "TRANSLATION_PROVIDER"
+      ? object.providerEnv
+      : undefined;
+  if (id === "deepseek") {
+    if (object.apiKeyEnv !== "DEEPSEEK_API_KEY") {
+      throw new Error(
+        "翻译配置.provider.apiKeyEnv 必须与 deepseek 匹配为 DEEPSEEK_API_KEY。",
+      );
+    }
+    if (object.modelEnv !== undefined && object.modelEnv !== "DEEPSEEK_MODEL") {
+      throw new Error(
+        "翻译配置.provider.modelEnv 必须与 deepseek 匹配为 DEEPSEEK_MODEL。",
+      );
+    }
+    return resolveTranslationProviderProfile(
+      {
+        apiKeyEnv: "DEEPSEEK_API_KEY",
+        id,
+        model,
+        ...(object.modelEnv === "DEEPSEEK_MODEL"
+          ? { modelEnv: object.modelEnv }
+          : {}),
+        ...(providerEnv ? { providerEnv } : {}),
+      },
+      environment,
+    );
   }
-  return {
-    apiKeyEnv: "DEEPSEEK_API_KEY",
-    id: "deepseek",
-    model: requiredString(object, "model", "翻译配置.provider"),
-  };
+  if (id === "minimax" || id === "minimax-cn") {
+    if (object.apiKeyEnv !== "MINIMAX_API_KEY") {
+      throw new Error(
+        `翻译配置.provider.apiKeyEnv 必须与 ${id} 匹配为 MINIMAX_API_KEY。`,
+      );
+    }
+    if (object.modelEnv !== undefined && object.modelEnv !== "MINIMAX_MODEL") {
+      throw new Error(
+        `翻译配置.provider.modelEnv 必须与 ${id} 匹配为 MINIMAX_MODEL。`,
+      );
+    }
+    return resolveTranslationProviderProfile(
+      {
+        apiKeyEnv: "MINIMAX_API_KEY",
+        id,
+        model,
+        ...(object.modelEnv === "MINIMAX_MODEL"
+          ? { modelEnv: object.modelEnv }
+          : {}),
+        ...(providerEnv ? { providerEnv } : {}),
+      },
+      environment,
+    );
+  }
+  throw new Error(
+    "翻译配置.provider.id 必须是 deepseek、minimax 或 minimax-cn。",
+  );
 }
 
 function validateGlossary(raw: unknown): TranslationGlossary {
@@ -667,10 +732,12 @@ export function classifyTranslationPage(input: {
 export async function loadTranslationWorkspace(
   repositoryRoot: string,
   configPath = "scripts/translation.config.json",
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<TranslationWorkspaceSnapshot> {
   const root = await realpath(resolve(repositoryRoot));
   const config = parseConfig(
     await readJson(root, repositoryPath(root, configPath), "翻译配置"),
+    environment,
   );
   const sourcePages = parseSourceManifest(
     await readJson(

--- a/scripts/translation/provider-profile.ts
+++ b/scripts/translation/provider-profile.ts
@@ -1,0 +1,75 @@
+import type { TranslationProviderProfile } from "./types.ts";
+
+type TranslationProviderId = TranslationProviderProfile["id"];
+
+const DEFAULT_MODELS: Readonly<Record<TranslationProviderId, string>> = {
+  deepseek: "deepseek-chat",
+  minimax: "MiniMax-M3",
+  "minimax-cn": "MiniMax-M3",
+};
+
+function configuredKey(value: string | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function isProviderId(value: string): value is TranslationProviderId {
+  return (
+    value === "deepseek" || value === "minimax" || value === "minimax-cn"
+  );
+}
+
+function selectedProviderId(
+  profile: TranslationProviderProfile,
+  environment: NodeJS.ProcessEnv,
+): TranslationProviderId {
+  if (!profile.providerEnv) return profile.id;
+
+  const explicit = environment[profile.providerEnv]?.trim();
+  if (explicit) {
+    if (!isProviderId(explicit)) {
+      throw new Error(
+        "TRANSLATION_PROVIDER 必须是 deepseek、minimax 或 minimax-cn。",
+      );
+    }
+    return explicit;
+  }
+
+  const hasDeepSeek = configuredKey(environment.DEEPSEEK_API_KEY);
+  const hasMinimax = configuredKey(environment.MINIMAX_API_KEY);
+  if (hasDeepSeek && hasMinimax) {
+    throw new Error(
+      "检测到多个翻译 API Key；请设置 TRANSLATION_PROVIDER 指明本次使用 deepseek、minimax 或 minimax-cn。",
+    );
+  }
+  if (hasDeepSeek) return "deepseek";
+  if (hasMinimax) {
+    return profile.id === "minimax" || profile.id === "minimax-cn"
+      ? profile.id
+      : "minimax-cn";
+  }
+  return profile.id;
+}
+
+export function resolveTranslationProviderProfile(
+  profile: TranslationProviderProfile,
+  environment: NodeJS.ProcessEnv = process.env,
+): TranslationProviderProfile {
+  const id = selectedProviderId(profile, environment);
+  const apiKeyEnv =
+    id === "deepseek" ? "DEEPSEEK_API_KEY" : "MINIMAX_API_KEY";
+  const modelEnv = id === "deepseek" ? "DEEPSEEK_MODEL" : "MINIMAX_MODEL";
+  const defaultModel = id === profile.id ? profile.model : DEFAULT_MODELS[id];
+  const model = environment[modelEnv]?.trim() || defaultModel;
+  const environmentSettings = profile.providerEnv
+    ? { modelEnv, providerEnv: profile.providerEnv }
+    : profile.modelEnv
+      ? { modelEnv: profile.modelEnv }
+      : {};
+
+  return {
+    apiKeyEnv,
+    id,
+    model,
+    ...environmentSettings,
+  } as TranslationProviderProfile;
+}

--- a/scripts/translation/provider.ts
+++ b/scripts/translation/provider.ts
@@ -1,4 +1,8 @@
-import { createDeepSeekProvider } from "@easy-translate/providers";
+import {
+  createDeepSeekProvider,
+  createMinimaxCNProvider,
+  createMinimaxProvider,
+} from "@easy-translate/providers";
 import {
   TranslationErrorCode,
   TranslationResponseError,
@@ -8,6 +12,7 @@ import {
 } from "@easy-translate/core";
 
 import type { MarkdownTranslationContext } from "./markdown-adapter.ts";
+import { resolveTranslationProviderProfile } from "./provider-profile.ts";
 import type { TranslationProviderProfile } from "./types.ts";
 
 interface PreserveReplacement {
@@ -803,12 +808,40 @@ export function createConfiguredProvider(
   preserveTerms: readonly string[] = [],
   terminology: Readonly<Record<string, string>> = {},
 ): TranslationProvider<MarkdownTranslationContext> {
-  const apiKey = environment[profile.apiKeyEnv]?.trim();
+  const resolvedProfile = resolveTranslationProviderProfile(
+    profile,
+    environment,
+  );
+  const apiKey = environment[resolvedProfile.apiKeyEnv]?.trim();
   if (!apiKey) {
     throw new Error(
-      `缺少环境变量 ${profile.apiKeyEnv}；请在本地配置 DeepSeek API key 后重试。`,
+      `缺少环境变量 ${resolvedProfile.apiKeyEnv}；请配置 ${resolvedProfile.id} API key 后重试。`,
     );
   }
+  const provider =
+    resolvedProfile.id === "deepseek"
+      ? createDeepSeekProvider({ apiKey, model: resolvedProfile.model })
+      : resolvedProfile.id === "minimax-cn"
+        ? createMinimaxCNProvider({
+            apiKey,
+            model: resolvedProfile.model,
+            extraBody: {
+              reasoning_split: true,
+              ...(resolvedProfile.model.startsWith("MiniMax-M3")
+                ? { thinking: { type: "disabled" } }
+                : {}),
+            },
+          })
+        : createMinimaxProvider({
+            apiKey,
+            model: resolvedProfile.model,
+            extraBody: {
+              reasoning_split: true,
+              ...(resolvedProfile.model.startsWith("MiniMax-M3")
+                ? { thinking: { type: "disabled" } }
+                : {}),
+            },
+          });
   return createSourceLineBreakNormalizationProvider(
     createFragmentedArticleFallbackProvider(
       createLiteralMarkdownDelimiterProvider(
@@ -816,7 +849,7 @@ export function createConfiguredProvider(
           createPreserveTermsProvider(
             createTerminologyProvider(
               createInvalidIdRecoveryProvider(
-                createDeepSeekProvider({ apiKey, model: profile.model }),
+                provider,
               ),
               preserveTerms,
               terminology,

--- a/scripts/translation/types.ts
+++ b/scripts/translation/types.ts
@@ -16,11 +16,21 @@ export interface TranslationConfig {
   translationManifestPath: string;
 }
 
-export interface TranslationProviderProfile {
-  apiKeyEnv: "DEEPSEEK_API_KEY";
-  id: "deepseek";
-  model: string;
-}
+export type TranslationProviderProfile =
+  | {
+      apiKeyEnv: "DEEPSEEK_API_KEY";
+      id: "deepseek";
+      model: string;
+      modelEnv?: "DEEPSEEK_MODEL";
+      providerEnv?: "TRANSLATION_PROVIDER";
+    }
+  | {
+      apiKeyEnv: "MINIMAX_API_KEY";
+      id: "minimax" | "minimax-cn";
+      model: string;
+      modelEnv?: "MINIMAX_MODEL";
+      providerEnv?: "TRANSLATION_PROVIDER";
+    };
 
 export interface TranslationGlossary {
   preserve: string[];


### PR DESCRIPTION
## 概要

- 复用 `@easy-translate/providers`，为翻译流程增加 DeepSeek、MiniMax 国际站与国内站预设
- 根据已配置的 API Key 自动选择唯一供应商；多个 Key 同时存在时要求设置 `TRANSLATION_PROVIDER`
- 支持通过 `MINIMAX_MODEL` / `DEEPSEEK_MODEL` 切换模型，并让实际 provider/model 进入翻译策略指纹
- GitHub Action 从 `translation-production` Environment 注入供应商密钥和模型变量
- 为 MiniMax M3 分离推理内容并关闭思考，以保持严格 JSON 翻译响应

## Environment 配置

- Secrets：`MINIMAX_API_KEY` 和/或 `DEEPSEEK_API_KEY`
- Variables：`MINIMAX_MODEL`、`DEEPSEEK_MODEL`
- 两个 Secret 都存在时：设置 `TRANSLATION_PROVIDER=minimax-cn|minimax|deepseek`

## 验证

- `pnpm typecheck`
- `pnpm test`（97 项）
- `pnpm translate:check`
- `git diff --check origin/main...HEAD`