### PR TITLE
[AI] feat: 将自动翻译上限提高到 100

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -92,12 +92,12 @@ jobs:
           pnpm test
           pnpm translate:check
 
-      - name: Translate up to ten budgeted pages
+      - name: Translate up to 100 budgeted pages
         if: steps.open-pr.outputs.exists != 'true'
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
-        run: pnpm translate:auto -- --limit 10
+        run: pnpm translate:auto -- --limit 100
 
       - name: Publish the translation branch
         if: steps.open-pr.outputs.exists != 'true'
@@ -151,7 +151,7 @@ jobs:
             const body = [
               "## 自动中文翻译",
               "",
-              "本 PR 由受信任的 `main` 工作流使用环境配置的大模型供应商自动生成，每次最多处理十篇受预算约束的页面。",
+              "本 PR 由受信任的 `main` 工作流使用环境配置的大模型供应商自动生成，每次最多处理 100 篇受预算约束的页面。",
               "",
               "### 文件",
               "",

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -141,7 +141,7 @@ pnpm test
 - provider/model 已进入策略哈希，checkpoint 路径也绑定策略 SHA。`translate:run` 仍限定单篇，默认无写入，只有显式 `--commit` 才落盘。
 - 多行官方导航卡片已纳入受限翻译范围；相邻正文和链接标签共享批次，减少行内链接拆分导致的语序问题。
 - `translate:review` 只接受 `current` 或 `modified-target`，重新核对源、策略和 Markdown 受保护结构后登记人工版本的目标 SHA，并将状态提升为 `reviewed`。
-- `translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 处理；同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序筛选，最后回退到稳定路径排序。每轮最多十篇，每篇都不超过 20,000 个源字符。
+- `translate:auto -- --limit 100` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 处理；同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序筛选，最后回退到稳定路径排序。每轮最多 100 篇，每篇都不超过 20,000 个源字符。
 - `translate-docs.yml` 只检出 `main`，先跑离线门禁，再仅向 DeepSeek 步骤注入环境 secret；已有翻译 PR 时停止。它在英文合入后触发，并每天北京时间 01:00 补充运行。
 - CI 已改用 `translate:check`，允许 pending/stale，但拒绝缺失、未登记或被修改而未 review 的目标文件。
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行�
 
 在 **Environment secrets** 中配置 `MINIMAX_API_KEY` 或 `DEEPSEEK_API_KEY`。只有一个 Key 时会自动选择对应供应商；仅有 MiniMax Key 时默认选择国内站 `minimax-cn`。同时存在两个 Key 时必须在 **Environment variables** 中设置 `TRANSLATION_PROVIDER`，值只能是上表中的键名。模型可通过同处的 `MINIMAX_MODEL` 或 `DEEPSEEK_MODEL` 切换，无需修改仓库或创建 PR。MiniMax 国内站 Plan 应使用 `minimax-cn`；国内站与国际站的 Key 和额度按各自接口生效，不应混用。
 
-运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译十篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
+运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译 100 篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
 
 仓库必须在 **Settings → Actions → General → Workflow permissions** 中启用 **Allow GitHub Actions to create and approve pull requests**。`main` 的 Ruleset 可以因此保持空 bypass，并要求所有更新通过 PR 和 `Quality gate`。PR 标题必须以 `[AI] ` 或 `[Human] ` 标明来源，其中 `codex/` 与 `automation/` 分支强制使用 `[AI] `。
 
-`translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端按优先级选择最多十篇受预算约束的页面；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。
+`translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端按优先级选择最多 100 篇受预算约束的页面；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。
 
 人工校对中可复用的固定译法应进入术语表，通用表达要求应进入翻译提示词；只适用于单篇文档的上下文、歧义或官方原文勘误记录在 `scripts/translation/review-notes.zh-CN.json`。页面级备注会自动加入该页翻译请求和策略 SHA，仅让对应页面进入 `stale-policy`，不会触发全站重翻。
 

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -98,7 +98,7 @@ Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` �
 2. **Markdown adapter（已完成）**：source-position 提取/还原、保护不变量、fixture 测试，并对齐 `@easy-translate/core` 的 `DocumentAdapter`。
 3. **本地翻译执行器（已完成）**：Core、checkpoint、单篇选择、质量策略、DeepSeek profile 和显式原子提交。
 4. **质量与人工校对（已完成基础闭环）**：结构检查、术语检查、显式 review 收录和 stale 传播；后续补充未登记文件的 adopt 流程。
-5. **自动翻译 PR（已完成首轮生产验收）**：英文变化合入 `main` 后立即触发，并每天补充执行；每轮最多十篇、单篇 20,000 源字符上限、单一待审核 PR，继续服从 `Quality gate` 和 `main` Ruleset。
+5. **自动翻译 PR（已完成首轮生产验收）**：英文变化合入 `main` 后立即触发，并每天补充执行；每轮最多 100 篇、单篇 20,000 源字符上限、单一待审核 PR，继续服从 `Quality gate` 和 `main` Ruleset。
 6. **内容积累（当前）**：按核心文档优先级积累中文页面，观察流水线稳定性后再扩大单轮吞吐。
 
 任何阶段都不得把模型凭据写入仓库，也不得直接 push `main`。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -141,7 +141,7 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `.github/workflows/translate-docs.yml` 在 `docs/en` 变更合入 `main` 后触发，并每天北京时间 01:00（UTC 17:00）补充运行。工作流只检出受信任的 `main`，在类型检查、测试和 `translate:check` 全部通过后，才把 `translation-production` 环境中的 `DEEPSEEK_API_KEY` 注入翻译步骤。
 
-`translate:auto -- --limit 10` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多十篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
+`translate:auto -- --limit 100` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多 100 篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
 生产翻译采用分层恢复：术语表的 `preserve` 项在发送前按最长匹配包裹为唯一的成对保护标记，标记内保留可见原词；模型复制标记、去掉外壳或改写成对标记内文本时，返回后都会恢复原词，任何保护标记残留都会被拒绝。指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。当一个 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，术语表仍随完整批次发送给模型，但质量门不再要求每个片段各自包含目标术语，避免中文调整语序后被误判。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间；同一质量错误再次出现时提前终止。批次仍失败时，只有格式响应错误和可重试 Provider 错误会在等待 10–12 秒后从 checkpoint 做一次页面恢复，质量错误不再整页重试。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
 

--- a/scripts/tests/translation-planner.test.ts
+++ b/scripts/tests/translation-planner.test.ts
@@ -783,20 +783,20 @@ test("translation CLI parses filters without changing defaults", () => {
     matches: [],
     section: "all",
   });
-  assert.deepEqual(parseCliOptions(["auto", "--limit", "10"]), {
+  assert.deepEqual(parseCliOptions(["auto", "--limit", "100"]), {
     command: "auto",
     commit: false,
     configPath: "scripts/translation.config.json",
-    limit: 10,
+    limit: 100,
     matches: [],
     section: "all",
   });
-  assert.throws(() => parseCliOptions(["auto"]), /--limit 10/u);
+  assert.throws(() => parseCliOptions(["auto"]), /--limit 100/u);
   assert.throws(
-    () => parseCliOptions(["auto", "--limit", "10", "--match", "page"]),
+    () => parseCliOptions(["auto", "--limit", "100", "--match", "page"]),
     /不允许 --match/u,
   );
-  assert.throws(() => parseCliOptions(["auto", "--limit", "1"]), /--limit 10/u);
+  assert.throws(() => parseCliOptions(["auto", "--limit", "1"]), /--limit 100/u);
 });
 
 test("automatic selection prioritizes stale work and integrity rejects target drift", () => {

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -58,7 +58,7 @@ type SourcedTranslationPageInspection = TranslationPageInspection & {
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_CONFIG_PATH = "scripts/translation.config.json";
 const AUTO_MAX_SOURCE_CHARACTERS = 20_000;
-const AUTO_PAGE_LIMIT = 10;
+const AUTO_PAGE_LIMIT = 100;
 const TRANSLATION_BATCH_RETRY_POLICY = {
   baseDelayMs: 1_000,
   jitterMs: 250,


### PR DESCRIPTION
## 变更

- 将中文翻译 GitHub Action 的单轮页面上限从 10 提高到 100
- 同步更新 CLI 的自动模式限制，避免工作流被本地安全校验拒绝
- 更新测试、自动 PR 文案和相关说明文档
- 保留最新的 DeepSeek/MiniMax 可配置供应商支持

## 验证

- `pnpm typecheck`
- `pnpm test`（97 项通过）
- `pnpm translate:check`