### PR TITLE
[AI] feat: 展示文档翻译状态

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -73,6 +73,13 @@ button, input { font: inherit; }
 .sidebar-heading { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; padding: 0 6px; }
 .sidebar-heading span { font-size: .929rem; font-weight: 800; }
 .sidebar-heading strong { border-radius: 99px; padding: 3px 7px; background: var(--soft); color: var(--muted); font-size: .786rem; }
+.translation-status-legend { display: flex; align-items: center; flex-wrap: wrap; gap: 7px 13px; color: #8b9690; font-size: .714rem; }
+.translation-status-legend > span { display: inline-flex; align-items: center; gap: 6px; }
+.sidebar > .translation-status-legend { margin: -7px 4px 10px; }
+.translation-status-dot { display: inline-block; width: 7px; height: 7px; flex: none; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 10%, transparent); }
+.translation-status-dot.current { color: #16805b; }
+.translation-status-dot.stale { color: #946719; }
+.translation-status-dot.pending { color: #b34d47; }
 .sidebar-groups details { border-top: 1px solid #edf0ee; }
 .sidebar-groups summary {
   display: flex;
@@ -93,7 +100,6 @@ button, input { font: inherit; }
 .sidebar-links { display: flex; padding: 0 0 9px 13px; flex-direction: column; gap: 2px; }
 .sidebar-links a { display: flex; min-width: 0; align-items: center; gap: 7px; border-radius: 7px; padding: 7px 8px; color: #68746e; font-size: .857rem; line-height: 1.45; }
 .sidebar-links a span { overflow: hidden; text-overflow: ellipsis; }
-.sidebar-links a i { width: 5px; height: 5px; flex: none; border-radius: 50%; background: var(--accent); }
 .sidebar-links a small { margin-left: auto; color: #9aa39e; }
 .sidebar-links a:hover { background: var(--soft); color: var(--ink); }
 .sidebar-links a.active { background: var(--accent-soft); color: var(--accent-dark); font-weight: 700; }
@@ -108,9 +114,17 @@ button, input { font: inherit; }
 .eyebrow { margin: 0 0 9px; color: var(--accent); font-size: .857rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
 h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; letter-spacing: -.045em; }
 .lead { max-width: 680px; margin: 18px 0 0; color: #53605a; font-size: 1.143rem; line-height: 1.8; }
+.document-badges { display: flex; margin-top: 18px; align-items: center; flex-wrap: wrap; gap: 8px; }
 .reviewed-badge { flex: none; border-radius: 99px; padding: 6px 9px; background: var(--accent-soft); color: var(--accent); font-size: .786rem; font-weight: 700; }
 .reviewed-badge.machine { background: var(--warm); color: #79692e; }
 .reviewed-badge.source { background: #eef1f7; color: #52627c; }
+.translation-status-badge { display: inline-flex; align-items: center; gap: 7px; border-radius: 99px; padding: 6px 10px; font-size: .786rem; font-weight: 800; }
+.translation-status-badge i { width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+.translation-status-badge.current { background: #e8f5ef; color: #16805b; }
+.translation-status-badge.stale { background: #f7efdf; color: #946719; }
+.translation-status-badge.pending { background: #f8eae8; color: #b34d47; }
+.translation-status-note { display: flex; margin: 11px 0 0; align-items: baseline; flex-wrap: wrap; gap: 5px; color: #7e8983; font-size: .786rem; line-height: 1.6; }
+.translation-status-note a { color: var(--accent-dark); font-weight: 800; }
 .document-timestamps { display: flex; margin: 24px 0 0; align-items: center; flex-wrap: wrap; gap: 10px 22px; color: var(--muted); }
 .document-timestamps > div { display: flex; align-items: baseline; gap: 7px; }
 .document-timestamps dt { color: #87918c; font-size: .786rem; font-weight: 700; }
@@ -162,6 +176,7 @@ h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; le
 .section-summary strong { margin-left: 20px; font-size: 1.571rem; }
 .section-summary strong:first-child { margin-left: 0; }
 .section-summary span { color: var(--muted); font-size: .786rem; }
+.section-translation-legend { display: flex; margin: -28px 0 38px; justify-content: flex-end; }
 .section-groups { display: flex; flex-direction: column; gap: 44px; }
 .section-groups > section > header { display: flex; align-items: baseline; gap: 10px; border-bottom: 1px solid var(--line); padding-bottom: 12px; }
 .section-groups h2 { margin: 0; font-size: 1.571rem; letter-spacing: -.025em; }
@@ -171,6 +186,8 @@ h1 { margin: 0; font-size: clamp(2.429rem, 5vw, 3.714rem); line-height: 1.08; le
 .section-entry-list a { display: flex; min-width: 0; align-items: center; justify-content: space-between; gap: 12px; border-bottom: 1px solid #edf0ee; padding: 11px 2px; color: #4f5d56; font-size: .857rem; }
 .section-entry-list a:hover span { color: var(--accent); }
 .section-entry-list a > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.section-entry-title { display: inline-flex; min-width: 0; align-items: center; gap: 9px; }
+.section-entry-title > span { overflow: hidden; text-overflow: ellipsis; }
 .section-entry-list small { flex: none; color: #949e99; font-size: .786rem; }
 
 /* Local untranslated page */
@@ -309,9 +326,9 @@ summary:focus-visible { outline: 3px solid rgba(8,122,87,.22); outline-offset: 3
   .sidebar-groups summary { border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px; }
   .sidebar-groups summary::before, .sidebar-groups summary small { display: none; }
   .sidebar-groups details[open] { width: min(280px, calc(100vw - 40px)); }
+  .sidebar > .translation-status-legend { display: none; }
   .sidebar-links { max-height: 260px; overflow-y: auto; padding: 7px 0; }
   .document-heading { display: block; }
-  .reviewed-badge { display: inline-block; margin-top: 16px; }
   .source-notice { align-items: flex-start; flex-direction: column; }
   .section-entry-list { grid-template-columns: 1fr; }
   .home-header { padding: 0 18px; }

--- a/apps/web/components/document-reader.tsx
+++ b/apps/web/components/document-reader.tsx
@@ -8,10 +8,10 @@ import type {
   GeneratedDocument,
   Locale,
   NavigationSection,
+  TranslationContentState,
 } from "@/lib/documents";
 import {
   bilingualPageCount,
-  hasLocalizedDocument,
   headingIds,
   headingSlug,
   localizedDocumentTitle,
@@ -22,6 +22,7 @@ import {
   navigationSectionForRoute,
   oppositeLocale,
   sidebarNavigationGroups,
+  translationStateForRoute,
 } from "@/lib/documents";
 import { resolveDocumentAsset, rewriteDocumentLink } from "@/lib/links";
 
@@ -58,6 +59,59 @@ function sectionLabel(locale: Locale, section: NavigationSection): string {
 
 function groupLabel(locale: Locale, label: string): string {
   return locale === "zh" ? GROUP_LABELS[label] ?? label : label;
+}
+
+type TranslationVisualState = "current" | "pending" | "stale";
+
+function translationVisualState(
+  state: TranslationContentState,
+): TranslationVisualState {
+  return state === "stale-policy" || state === "stale-source"
+    ? "stale"
+    : state;
+}
+
+function translationStatusLabel(state: TranslationContentState): string {
+  if (state === "current") return "译文为最新";
+  if (state === "pending") return "尚未翻译";
+  return "译文待更新";
+}
+
+function TranslationStatusDot({ state }: { state: TranslationContentState }) {
+  const label = translationStatusLabel(state);
+  return (
+    <i
+      aria-label={label}
+      className={`translation-status-dot ${translationVisualState(state)}`}
+      title={label}
+    />
+  );
+}
+
+function TranslationStatusBadge({ state }: { state: TranslationContentState }) {
+  return (
+    <span className={`translation-status-badge ${translationVisualState(state)}`}>
+      <i aria-hidden="true" />
+      {translationStatusLabel(state)}
+    </span>
+  );
+}
+
+function TranslationStatusLegend() {
+  return (
+    <div className="translation-status-legend" aria-label="中文翻译状态图例">
+      {([
+        ["current", "最新"],
+        ["stale-source", "待更新"],
+        ["pending", "未翻译"],
+      ] as const).map(([state, label]) => (
+        <span key={state}>
+          <TranslationStatusDot state={state} />
+          {label}
+        </span>
+      ))}
+    </div>
+  );
 }
 
 function nodeText(node: ReactNode): string {
@@ -168,6 +222,7 @@ function DocsSidebar({ locale, route }: { locale: Locale; route: string }) {
         <span>{sectionLabel(locale, section)}</span>
         <strong>{section.groups.reduce((total, group) => total + group.entries.length, 0)}</strong>
       </div>
+      {locale === "zh" && <TranslationStatusLegend />}
       <div className="sidebar-groups">
         {sidebarNavigationGroups(section).map((group) => (
           <details key={group.title} open={activeGroup?.title === group.title}>
@@ -177,15 +232,17 @@ function DocsSidebar({ locale, route }: { locale: Locale; route: string }) {
             </summary>
             <div className="sidebar-links">
               {group.entries.map((entry) => {
-                const available = hasLocalizedDocument(locale, entry.route);
+                const translationState = translationStateForRoute(entry.route);
                 return (
                   <Link
                     className={entry.route === route ? "active" : ""}
                     href={localizedRoute(locale, entry.route)}
                     key={entry.route}
                   >
+                    {locale === "zh" && (
+                      <TranslationStatusDot state={translationState} />
+                    )}
                     <span>{localizedDocumentTitle(locale, entry)}</span>
-                    {locale === "zh" && available && <i aria-label="已有中文译文" />}
                   </Link>
                 );
               })}
@@ -235,6 +292,7 @@ export function DocumentReader({ document }: { document: GeneratedDocument }) {
   const neighbors = navigationNeighbors(document.route);
   const toc = headingIds(document.headings);
   const isSource = document.reviewStatus === "source";
+  const translationState = document.translationState ?? "pending";
 
   return (
     <DocsShell
@@ -261,14 +319,30 @@ export function DocumentReader({ document }: { document: GeneratedDocument }) {
           <div>
             <p className="eyebrow">{group ? groupLabel(locale, group.title) : sectionLabel(locale, section)}</p>
             <h1>{document.title}</h1>
+            <div className="document-badges">
+              {locale === "zh" && (
+                <TranslationStatusBadge state={translationState} />
+              )}
+              <span className={`reviewed-badge ${document.reviewStatus}`}>
+                {isSource
+                  ? "English source"
+                  : document.reviewStatus === "reviewed"
+                    ? locale === "zh" ? "人工校对" : "Human reviewed"
+                    : locale === "zh" ? "机器翻译" : "Machine translated"}
+              </span>
+            </div>
+            {locale === "zh" && translationState === "stale-source" && (
+              <p className="translation-status-note">
+                英文原文已更新，中文版本尚未同步。
+                <Link href={localizedRoute("en", document.route)}>查看英文最新版 →</Link>
+              </p>
+            )}
+            {locale === "zh" && translationState === "stale-policy" && (
+              <p className="translation-status-note">
+                翻译规则已更新，当前译文尚未按新规则重译。
+              </p>
+            )}
           </div>
-          <span className={`reviewed-badge ${document.reviewStatus}`}>
-            {isSource
-              ? "English source"
-              : document.reviewStatus === "reviewed"
-                ? locale === "zh" ? "人工校对" : "Human reviewed"
-                : locale === "zh" ? "机器翻译" : "Machine translated"}
-          </span>
         </div>
 
         <dl className="document-timestamps">
@@ -358,6 +432,11 @@ export function SectionIndex({
           <strong>{pageCount}</strong><span>{locale === "zh" ? "篇页面" : "pages"}</span>
           <strong>{bilingualPageCount}</strong><span>{locale === "zh" ? "篇中文译文" : "Chinese translations"}</span>
         </div>
+        {locale === "zh" && (
+          <div className="section-translation-legend">
+            <TranslationStatusLegend />
+          </div>
+        )}
         <div className="section-groups">
           {section.groups.map((group) => (
             <section id={headingSlug(group.title)} key={group.title}>
@@ -367,16 +446,24 @@ export function SectionIndex({
                 <span>{group.entries.length + group.externalEntries.length}</span>
               </header>
               <div className="section-entry-list">
-                {group.entries.map((entry) => (
-                  <Link href={localizedRoute(locale, entry.route)} key={entry.route}>
-                    <span>{localizedDocumentTitle(locale, entry)}</span>
-                    <small>
-                      {locale === "zh" && hasLocalizedDocument("zh", entry.route)
-                        ? "中文可读"
-                        : locale === "zh" ? "英文原文" : "Open page"}
-                    </small>
-                  </Link>
-                ))}
+                {group.entries.map((entry) => {
+                  const translationState = translationStateForRoute(entry.route);
+                  return (
+                    <Link href={localizedRoute(locale, entry.route)} key={entry.route}>
+                      <span className="section-entry-title">
+                        {locale === "zh" && (
+                          <TranslationStatusDot state={translationState} />
+                        )}
+                        <span>{localizedDocumentTitle(locale, entry)}</span>
+                      </span>
+                      <small>
+                        {locale === "zh"
+                          ? translationStatusLabel(translationState)
+                          : "Open page"}
+                      </small>
+                    </Link>
+                  );
+                })}
                 {group.externalEntries.map((entry) => (
                   <a href={entry.sourceUrl} key={entry.sourceUrl} rel="noopener noreferrer" target="_blank">
                     <span>{entry.title}</span>
@@ -414,6 +501,11 @@ export function MissingDocument({
         </div>
         <p className="eyebrow">{locale === "zh" ? "中文翻译进行中" : "Not bundled yet"}</p>
         <h1>{title}</h1>
+        {locale === "zh" && (
+          <div className="document-badges">
+            <TranslationStatusBadge state="pending" />
+          </div>
+        )}
         <p>
           {locale === "zh"
             ? "这篇页面已处于和官网一致的目录位置，但中文译文尚未生成。你可以先阅读本站静态渲染的英文原文，不会被自动带离本站。"

--- a/apps/web/lib/documents.ts
+++ b/apps/web/lib/documents.ts
@@ -6,6 +6,11 @@ import {
 } from "@/generated/documents";
 
 export type Locale = "en" | "zh";
+export type TranslationContentState =
+  | "current"
+  | "pending"
+  | "stale-policy"
+  | "stale-source";
 
 export interface DocumentMetadata {
   bytes: number;
@@ -18,6 +23,7 @@ export interface DocumentMetadata {
   sourceUrl: string;
   sourceUpdatedAt: string;
   translatedAt?: string;
+  translationState?: TranslationContentState;
   reviewStatus: "machine" | "reviewed" | "source";
 }
 
@@ -35,6 +41,7 @@ export interface CatalogDocument {
   section: "guides" | "reference";
   sourceUrl: string;
   sourceUpdatedAt: string;
+  translationState: TranslationContentState;
 }
 
 export type NavigationEntry = CatalogDocument;
@@ -164,6 +171,10 @@ export function localizedDocumentTitle(locale: Locale, entry: NavigationEntry): 
 
 export function hasLocalizedDocument(locale: Locale, route: string): boolean {
   return Boolean(documentMetadataForRoute(locale, route));
+}
+
+export function translationStateForRoute(route: string): TranslationContentState {
+  return catalogDocumentForRoute(route)?.translationState ?? "pending";
 }
 
 export function allGeneratedDocuments(): DocumentMetadata[] {

--- a/apps/web/scripts/generate-content.ts
+++ b/apps/web/scripts/generate-content.ts
@@ -38,6 +38,7 @@ interface NavigationEntry {
   route: string;
   sourceUrl: string;
   title: string;
+  translationState: TranslationContentState;
 }
 
 interface NavigationGroup {
@@ -62,7 +63,14 @@ interface ContentRecord {
   sourceUpdatedAt: string;
   title: string;
   translatedAt?: string;
+  translationState?: TranslationContentState;
 }
+
+type TranslationContentState =
+  | "current"
+  | "pending"
+  | "stale-policy"
+  | "stale-source";
 
 interface SyncReleaseEntry {
   path: string;
@@ -234,6 +242,20 @@ async function main(): Promise<void> {
     throw new Error("首页翻译状态未覆盖全部有效英文页面。");
   }
 
+  const translationStateBySourceUrl = new Map<string, TranslationContentState>();
+  for (const entry of translationWorkspace.entries) {
+    if (!entry.source || entry.source.status !== "active") continue;
+    if (
+      entry.state !== "current" &&
+      entry.state !== "pending" &&
+      entry.state !== "stale-policy" &&
+      entry.state !== "stale-source"
+    ) {
+      throw new Error(`英文页面存在无法展示的翻译状态：${entry.source.sourceUrl}`);
+    }
+    translationStateBySourceUrl.set(entry.source.sourceUrl, entry.state);
+  }
+
   const syncReleases = await Promise.all(
     updateFiles
       .filter((fileName) => fileName.endsWith(".json"))
@@ -254,6 +276,7 @@ async function main(): Promise<void> {
       sourceUpdatedAt: page.sourceUpdatedAt,
       contentPath: page.localPath,
       bytes: page.bytes,
+      translationState: translationStateBySourceUrl.get(page.sourceUrl) ?? "pending",
     }))
     .sort((left, right) => left.route.localeCompare(right.route));
 
@@ -328,6 +351,7 @@ async function main(): Promise<void> {
       sourceUrl: page.sourceUrl,
       sourceUpdatedAt: catalogPage.sourceUpdatedAt,
       translatedAt: page.translatedAt,
+      translationState: translationStateBySourceUrl.get(page.sourceUrl) ?? "pending",
       reviewStatus: page.reviewStatus,
     });
   }

--- a/apps/web/tests/document-content.test.ts
+++ b/apps/web/tests/document-content.test.ts
@@ -89,6 +89,11 @@ test("renders every document header in title, timestamps, source notice, body or
     1,
     "article body must not be duplicated into the document header",
   );
+  assert.match(html, /translation-status-badge/u);
+  assert.match(
+    html,
+    document.translationState === "current" ? /译文为最新/u : /译文待更新/u,
+  );
 });
 
 test("keeps external document bundles out of the ordinary article sidebar", () => {

--- a/apps/web/tests/links.test.ts
+++ b/apps/web/tests/links.test.ts
@@ -16,6 +16,7 @@ import {
   documentMetadataForRoute,
   navigation,
   sourcePageCount,
+  translationStateForRoute,
 } from "../lib/documents.js";
 import { loadDocumentForRoute } from "../lib/document-content.js";
 import { rewriteDocumentLink } from "../lib/links.js";
@@ -134,6 +135,20 @@ describe("document link rewriting", () => {
       translationStatus.staleSource + translationStatus.stalePolicy,
     );
     assert.equal(translationStatus.totalActive, sourcePageCount);
+  });
+
+  it("exposes the same translation state for navigation and document badges", () => {
+    const states = navigation().flatMap((section) =>
+      section.groups.flatMap((group) =>
+        group.entries.map((entry) => translationStateForRoute(entry.route)),
+      ),
+    );
+    assert.equal(states.filter((state) => state === "current").length, translationStatus.current);
+    assert.equal(states.filter((state) => state === "pending").length, translationStatus.pending);
+    assert.equal(
+      states.filter((state) => state === "stale-source" || state === "stale-policy").length,
+      translationStatus.stale,
+    );
   });
 
   it("leaves Vercel output detection to the Next.js preset", async () => {


### PR DESCRIPTION
## 变更

- 首页构建状态延伸到目录与索引，使用三色圆点展示最新、待更新和未翻译
- 文章标题下展示译文新鲜度与机器/人工审核两个独立标签
- 针对原文更新和规则更新解释原因，并为原文更新提供英文最新版入口
- 构建期生成每篇页面状态，并补充一致性测试

## 验证

- `pnpm web:typecheck`
- `pnpm web:lint`
- `pnpm web:test`
- `pnpm web:build`