### PR TITLE
[AI] feat: 添加 llms.txt 静态索引

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,6 +8,7 @@
 - `docs/zh/.translation-manifest.json` 提供当前中文译文；未翻译中文路径仍处于官网对应目录，并链接到本站英文原文。
 - `docs/en/api/docs/llms.txt` 与 `docs/en/api/reference/llms.txt` 是导航分组和顺序的权威来源。
 - `scripts/generate-content.ts` 只生成轻量元数据和内容路径；Markdown 在构建对应页面时按需读取，不会进入浏览器公共数据包。
+- `lib/llms.ts` 从当前文档清单生成精简双语索引，并由静态路由发布为根路径 `/llms.txt`。
 - 首页明确展示 `developers.openai.com` 为官方权威内容源，站点本身标注为社区镜像。
 
 ## 本地命令
@@ -64,6 +65,7 @@ NEXT_PUBLIC_SITE_ORIGIN=https://你的正式域名
 - `/zh/api/docs/...`：中文译文；尚未翻译时显示同结构状态页并提供本站英文入口。
 - `/en/api/docs/...`：仓库内英文 Markdown 的静态页面；超大事件/资源总表保留结构化路由并明确链接官网，后续按章节拆页。
 - `/zh|en/api/reference/...`：同样规则的 API 参考页面。
+- `/llms.txt`：供代理和大语言模型发现主要双语入口、常用文档与权威来源的精简索引。
 - 官方文档内部链接转换为当前语言的本站路由；即使目标尚未翻译，也不会自动跳回官网。
 - 第三方链接与非文档 OpenAI 链接保留为外部链接，并在新窗口打开。
 - `docs/en` 与 `docs/zh` 原文不会为展示目的被修改。

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -37,6 +37,9 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="zh-CN">
+      <head>
+        <link href="/llms.txt" rel="describedby" />
+      </head>
       <body>
         {children}
         <script

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,0 +1,11 @@
+import { buildLlmsText } from "@/lib/llms";
+
+export const dynamic = "force-static";
+
+export function GET(): Response {
+  return new Response(buildLlmsText(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/web/lib/llms.ts
+++ b/apps/web/lib/llms.ts
@@ -1,0 +1,177 @@
+import {
+  catalogDocumentForRoute,
+  documentMetadataForRoute,
+  localizedRoute,
+  type Locale,
+} from "@/lib/documents";
+import { siteOrigin } from "@/lib/site";
+
+interface FeaturedDocument {
+  descriptions: Record<Locale, string>;
+  route: string;
+}
+
+const featuredDocuments: readonly FeaturedDocument[] = [
+  {
+    route: "/api/docs/quickstart",
+    descriptions: {
+      zh: "完成首次 OpenAI API 请求。",
+      en: "Make a first OpenAI API request.",
+    },
+  },
+  {
+    route: "/api/docs/models",
+    descriptions: {
+      zh: "查看可用模型及其能力。",
+      en: "Review available models and their capabilities.",
+    },
+  },
+  {
+    route: "/api/docs/guides/text",
+    descriptions: {
+      zh: "使用 Responses API 生成文本。",
+      en: "Generate text with the Responses API.",
+    },
+  },
+  {
+    route: "/api/docs/guides/function-calling",
+    descriptions: {
+      zh: "让模型调用应用提供的工具。",
+      en: "Let models call tools provided by an application.",
+    },
+  },
+  {
+    route: "/api/docs/guides/tools-web-search",
+    descriptions: {
+      zh: "使用内置网络搜索工具获取最新信息。",
+      en: "Use the built-in web search tool for current information.",
+    },
+  },
+  {
+    route: "/api/docs/guides/image-generation",
+    descriptions: {
+      zh: "通过 API 生成和编辑图像。",
+      en: "Generate and edit images through the API.",
+    },
+  },
+  {
+    route: "/api/docs/guides/audio",
+    descriptions: {
+      zh: "构建语音与音频应用。",
+      en: "Build speech and audio applications.",
+    },
+  },
+  {
+    route: "/api/docs/guides/realtime",
+    descriptions: {
+      zh: "构建低延迟多模态应用。",
+      en: "Build low-latency multimodal applications.",
+    },
+  },
+  {
+    route: "/api/reference/responses/overview",
+    descriptions: {
+      zh: "查阅 Responses API 接口参考。",
+      en: "Read the Responses API reference.",
+    },
+  },
+] as const;
+
+function absoluteSiteUrl(origin: string, path: string): string {
+  return new URL(path, `${origin.replace(/\/$/u, "")}/`).toString();
+}
+
+function markdownText(value: string): string {
+  return value
+    .replace(/\s+/gu, " ")
+    .trim()
+    .replace(/\\/gu, "\\\\")
+    .replace(/\[/gu, "\\[")
+    .replace(/\]/gu, "\\]");
+}
+
+function linkLine(title: string, url: string, description: string): string {
+  return `- [${markdownText(title)}](${url}): ${markdownText(description)}`;
+}
+
+function featuredDocumentLines(locale: Locale, origin: string): string[] {
+  return featuredDocuments.flatMap((featured) => {
+    const catalogDocument = catalogDocumentForRoute(featured.route);
+    const localizedDocument = documentMetadataForRoute(locale, featured.route);
+    if (!catalogDocument || !localizedDocument) return [];
+
+    return [
+      linkLine(
+        localizedDocument.title || catalogDocument.title,
+        absoluteSiteUrl(origin, localizedRoute(locale, featured.route)),
+        featured.descriptions[locale],
+      ),
+    ];
+  });
+}
+
+export function buildLlmsText(origin = siteOrigin): string {
+  const chineseDocuments = featuredDocumentLines("zh", origin);
+  const englishDocuments = featuredDocumentLines("en", origin);
+  const lines = [
+    "# OpenAI API 中文文档",
+    "",
+    "> 社区维护的 OpenAI API 中英文文档镜像，提供中文译文、英文原文和双语对照入口。",
+    "",
+    "本站不是 OpenAI 官方网站。接口行为、价格、限制和安全要求应以 OpenAI 官方开发者文档为准。中文页面使用 `/zh/` 前缀，英文页面使用 `/en/` 前缀；页面会标明翻译与源文档状态。",
+    "",
+    "## 中文入口",
+    "",
+    linkLine(
+      "中文文档指南",
+      absoluteSiteUrl(origin, "/zh/api/docs"),
+      "OpenAI API 概念、指南和教程的中文入口。",
+    ),
+    linkLine(
+      "中文 API 参考",
+      absoluteSiteUrl(origin, "/zh/api/reference"),
+      "OpenAI API 资源、接口和事件的中文入口。",
+    ),
+    "",
+    "## English entry points",
+    "",
+    linkLine(
+      "English documentation",
+      absoluteSiteUrl(origin, "/en/api/docs"),
+      "English guides and conceptual documentation mirrored from the official source.",
+    ),
+    linkLine(
+      "English API reference",
+      absoluteSiteUrl(origin, "/en/api/reference"),
+      "English endpoint, resource, and event reference mirrored from the official source.",
+    ),
+    "",
+    ...(chineseDocuments.length > 0
+      ? ["## 常用中文文档", "", ...chineseDocuments, ""]
+      : []),
+    "## Common English documentation",
+    "",
+    ...englishDocuments,
+    "",
+    "## Project and authoritative source",
+    "",
+    linkLine(
+      "OpenAI 官方开发者文档",
+      "https://developers.openai.com/api/",
+      "所有 API 行为和产品信息的权威来源。",
+    ),
+    linkLine(
+      "OpenAI-API-Chinese GitHub repository",
+      "https://github.com/jiahim/OpenAI-API-Chinese",
+      "Source code, translation workflow, and contribution history for this community mirror.",
+    ),
+    linkLine(
+      "站点更新记录",
+      absoluteSiteUrl(origin, "/updates"),
+      "查看最近同步的官方文档变更。",
+    ),
+    "",
+  ];
+
+  return lines.join("\n");
+}

--- a/apps/web/tests/llms.test.ts
+++ b/apps/web/tests/llms.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { GET } from "../app/llms.txt/route.js";
+import {
+  catalogDocumentForRoute,
+  documentMetadataForRoute,
+} from "../lib/documents.js";
+import { buildLlmsText } from "../lib/llms.js";
+
+const TEST_ORIGIN = "https://docs.example.com";
+
+function localDocumentLinks(content: string): URL[] {
+  return [...content.matchAll(/\]\((https:\/\/docs\.example\.com\/[^)]+)\)/gu)]
+    .map((match) => new URL(match[1] ?? TEST_ORIGIN))
+    .filter((url) => /^\/(?:zh|en)\/api\/(?:docs|reference)\/.+/u.test(url.pathname));
+}
+
+describe("llms.txt", () => {
+  it("builds a concise bilingual index with provenance", () => {
+    const content = buildLlmsText(TEST_ORIGIN);
+
+    assert.match(content, /^# OpenAI API 中文文档\n/u);
+    assert.match(content, /社区维护/u);
+    assert.match(content, /不是 OpenAI 官方网站/u);
+    assert.match(content, /https:\/\/docs\.example\.com\/zh\/api\/docs/u);
+    assert.match(content, /https:\/\/docs\.example\.com\/en\/api\/reference/u);
+    assert.match(content, /https:\/\/developers\.openai\.com\/api\//u);
+    assert.match(content, /https:\/\/github\.com\/jiahim\/OpenAI-API-Chinese/u);
+    assert.doesNotMatch(content, /localhost/u);
+    assert.ok(content.length < 30_000);
+    assert.ok(content.endsWith("\n"));
+  });
+
+  it("only links featured pages that exist in the requested locale", () => {
+    const links = localDocumentLinks(buildLlmsText(TEST_ORIGIN));
+
+    assert.ok(links.length >= 10);
+    for (const link of links) {
+      const match = /^\/(zh|en)(\/api\/(?:docs|reference)\/.+)$/u.exec(link.pathname);
+      assert.ok(match?.[1] && match[2]);
+      const locale = match[1] as "zh" | "en";
+      const route = match[2];
+      assert.ok(catalogDocumentForRoute(route), `Missing catalog route: ${route}`);
+      assert.ok(
+        documentMetadataForRoute(locale, route),
+        `Missing ${locale} document: ${route}`,
+      );
+    }
+  });
+
+  it("serves the generated index as UTF-8 plain text", async () => {
+    const response = GET();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "text/plain; charset=utf-8");
+    assert.match(await response.text(), /^# OpenAI API 中文文档\n/u);
+  });
+});


### PR DESCRIPTION
## Summary

- add a statically exported /llms.txt generated from the current bilingual document catalog
- include curated Chinese and English entry points, project provenance, and the authoritative OpenAI source
- advertise the index with rel=describedby and document the new route
- validate output format, localized links, and response headers with automated tests

## Verification

- pnpm web:test
- pnpm web:typecheck
- pnpm web:lint
- pnpm web:build