### PR TITLE
[AI] fix: 过滤模型新增的反引号格式

### DIFF
--- a/scripts/tests/translation-provider.test.ts
+++ b/scripts/tests/translation-provider.test.ts
@@ -388,6 +388,33 @@ test("literal-backtick provider rejects markers moved across items", async () =>
   );
 });
 
+test("literal-backtick provider removes formatting added by the model", async () => {
+  const provider = defineProvider({
+    async translateBatch(request) {
+      return request.items.map((item) => ({
+        id: item.id,
+        text: "`prompt` 参数最多可包含 20 个唯一提示词。",
+      }));
+    },
+  });
+  const protectedProvider = createLiteralBacktickProvider(provider);
+
+  const output = await protectedProvider.translateBatch({
+    items: [
+      {
+        context: {},
+        id: "unit",
+        text: "The prompt parameter can hold up to 20 unique prompts.",
+      },
+    ],
+    targetLanguage: "zh-CN",
+  });
+
+  assert.deepEqual(output, [
+    { id: "unit", text: "prompt 参数最多可包含 20 个唯一提示词。" },
+  ]);
+});
+
 test("literal Markdown provider preserves source runs and removes added formatting", async () => {
   let observedText = "";
   const provider = defineProvider({

--- a/scripts/translation/provider.ts
+++ b/scripts/translation/provider.ts
@@ -712,7 +712,7 @@ export function createLiteralBacktickProvider<TContext>(
         );
       }
       return output.map((item) => {
-        let text = item.text;
+        let text = item.text.replace(LITERAL_BACKTICK_PATTERN, "");
         for (const replacement of replacements) {
           if (replacement.itemId !== item.id) continue;
           text = text.split(replacement.token).join(replacement.backticks);


### PR DESCRIPTION
## 问题

远端自动翻译在 `production-best-practices` 页面失败。模型为原文没有 Markdown 格式的 `prompt` 擅自增加反引号，触发字面 Markdown 结构质量校验。

## 修复

- 回填前移除模型新增的、未受保护的反引号。
- 继续通过保护标记精确恢复原文已有的反引号序列。
- 新增回归测试覆盖模型将普通 `prompt` 输出为行内代码的情况。

## 验证

- `pnpm test`（98 项通过）
- `pnpm typecheck`
- `pnpm translate:check`（422 篇完整性检查通过）