### PR TITLE
[AI] fix: 定向重译缺失保留词的单元

### DIFF
--- a/scripts/tests/translation-provider.test.ts
+++ b/scripts/tests/translation-provider.test.ts
@@ -643,6 +643,100 @@ test("preserve-term provider normalizes duplicated protected marker pairs", asyn
   assert.deepEqual(output, [{ id: "unit", text: "API / 接口" }]);
 });
 
+test("preserve-term provider retranslates only items missing protected terms", async () => {
+  const protectedSpanPattern =
+    /\{\{ET_KEEP_\d+_\d+_\d+_START\}\}API\{\{ET_KEEP_\d+_\d+_\d+_END\}\}/u;
+  const observedItemIds: string[][] = [];
+  const provider = defineProvider({
+    async translateBatch(request) {
+      observedItemIds.push(request.items.map((item) => item.id));
+      return request.items.map((item) => {
+        const protectedSpan = item.text.match(protectedSpanPattern)?.[0];
+        assert.ok(protectedSpan);
+        if (observedItemIds.length === 1 && item.id === "ephemeral") {
+          return { id: item.id, text: "浏览器向服务器请求临时密钥。" };
+        }
+        return {
+          id: item.id,
+          text:
+            item.id === "ephemeral"
+              ? `浏览器向服务器请求临时 ${protectedSpan} 密钥。`
+              : `服务器使用标准 ${protectedSpan} 密钥。`,
+        };
+      });
+    },
+  });
+  const protectedProvider = createPreserveTermsProvider(provider, ["API"]);
+  const output = await protectedProvider.translateBatch({
+    items: [
+      {
+        context: {},
+        id: "ephemeral",
+        text: "The browser requests an ephemeral API key.",
+      },
+      {
+        context: {},
+        id: "standard",
+        text: "The server uses a standard API key.",
+      },
+    ],
+    targetLanguage: "zh-CN",
+  });
+
+  assert.deepEqual(observedItemIds, [
+    ["ephemeral", "standard"],
+    ["ephemeral"],
+  ]);
+  assert.deepEqual(output, [
+    { id: "ephemeral", text: "浏览器向服务器请求临时 API 密钥。" },
+    { id: "standard", text: "服务器使用标准 API 密钥。" },
+  ]);
+});
+
+test("preserve-term recovery does not reclaim spans moved between items", async () => {
+  const protectedSpanPattern =
+    /\{\{ET_KEEP_\d+_\d+_\d+_START\}\}API\{\{ET_KEEP_\d+_\d+_\d+_END\}\}/u;
+  const observedItemIds: string[][] = [];
+  const provider = defineProvider({
+    async translateBatch(request) {
+      observedItemIds.push(request.items.map((item) => item.id));
+      if (observedItemIds.length === 1) {
+        const movedSpan = request.items[1]?.text.match(protectedSpanPattern)?.[0];
+        assert.ok(movedSpan);
+        return [
+          { id: "missing", text: "浏览器请求临时密钥。" },
+          { id: "moved-from", text: "服务器使用" },
+          { id: "moved-to", text: `${movedSpan} 密钥。` },
+        ];
+      }
+      const recoveredSpan = request.items[0]?.text.match(protectedSpanPattern)?.[0];
+      assert.ok(recoveredSpan);
+      return [
+        { id: "missing", text: `浏览器请求临时 ${recoveredSpan} 密钥。` },
+      ];
+    },
+  });
+  const protectedProvider = createPreserveTermsProvider(provider, ["API"]);
+  const output = await protectedProvider.translateBatch({
+    items: [
+      { context: {}, id: "missing", text: "Request an ephemeral API key." },
+      { context: {}, id: "moved-from", text: "Use an API" },
+      { context: {}, id: "moved-to", text: "key." },
+    ],
+    targetLanguage: "zh-CN",
+  });
+
+  assert.deepEqual(observedItemIds, [
+    ["missing", "moved-from", "moved-to"],
+    ["missing"],
+  ]);
+  assert.deepEqual(output, [
+    { id: "missing", text: "浏览器请求临时 API 密钥。" },
+    { id: "moved-from", text: "服务器使用" },
+    { id: "moved-to", text: "API 密钥。" },
+  ]);
+});
+
 test("preserve-term provider rejects a missing protected span", async () => {
   const protectedSpanPattern =
     /\{\{ET_KEEP_\d+_\d+_\d+_START\}\}API\{\{ET_KEEP_\d+_\d+_\d+_END\}\}/u;

--- a/scripts/translation/provider.ts
+++ b/scripts/translation/provider.ts
@@ -44,6 +44,9 @@ const PRESERVE_MARKER_INSTRUCTION =
   "fragmented items, move the entire pair instead of copying it. Never translate, omit, duplicate, or split a protected span." +
   " Do not introduce additional unmarked occurrences of protected terms, including by expanding generic or " +
   "possessive references into product or company names.";
+const PRESERVE_MISSING_RECOVERY_INSTRUCTION =
+  "MISSING PROTECTED SPAN RECOVERY: This request contains only response items that omitted one or more protected terms. " +
+  "Translate every item again and copy every complete {{ET_KEEP_*_START}}...{{ET_KEEP_*_END}} span exactly once.";
 const PRESERVE_MARKER_RESIDUE_PATTERN = /ET_KEEP_\d+_\d+_\d+/u;
 const TERMINOLOGY_MARKER_INSTRUCTION =
   "Paired {{ET_TERM_*_START}} and {{ET_TERM_*_END}} markers wrap glossary source terms. " +
@@ -356,9 +359,12 @@ export function createPreserveTermsProvider<TContext>(
   if (terms.length === 0) return provider;
 
   let requestIndex = 0;
-  return {
-    name: provider.name,
-    async translateBatch(request, signal, onActivity) {
+  async function translateBatch(
+    request: TranslationBatchRequest<TContext>,
+    signal?: AbortSignal,
+    onActivity?: Parameters<TranslationProvider<TContext>["translateBatch"]>[2],
+    allowMissingRecovery = true,
+  ): Promise<TranslationOutputItem[]> {
       const currentRequest = requestIndex;
       requestIndex += 1;
       const replacementsById = new Map<string, PreserveReplacement[]>();
@@ -444,9 +450,101 @@ export function createPreserveTermsProvider<TContext>(
         restoredOutput.map((item) => item.text),
         terms,
       );
-      for (const [term, expected] of expectedCounts) {
+      let countMismatch = [...expectedCounts].find(
+        ([term, expected]) => (actualCounts.get(term) ?? 0) !== expected,
+      );
+      if (
+        allowMissingRecovery &&
+        countMismatch !== undefined &&
+        (actualCounts.get(countMismatch[0]) ?? 0) < countMismatch[1]
+      ) {
+        const deficitTerms = new Set(
+          [...expectedCounts].flatMap(([term, expected]) =>
+            (actualCounts.get(term) ?? 0) < expected ? [term] : [],
+          ),
+        );
+        const presentReplacementTokens = new Set(
+          allReplacements.flatMap((replacement) =>
+            normalizedOutput.some(
+              (item) =>
+                item.text.includes(replacement.openToken) &&
+                item.text.includes(replacement.closeToken),
+            )
+              ? [replacement.openToken]
+              : [],
+          ),
+        );
+        const outputById = new Map(
+          restoredOutput.map((item) => [item.id, item.text]),
+        );
+        const recoveryIds = new Set<string>();
+        for (const item of request.items) {
+          const replacements = replacementsById.get(item.id) ?? [];
+          if (replacements.length === 0) continue;
+          const itemExpectedCounts = new Map<string, number>();
+          for (const replacement of replacements) {
+            itemExpectedCounts.set(
+              replacement.term,
+              (itemExpectedCounts.get(replacement.term) ?? 0) + 1,
+            );
+          }
+          const itemActualCounts = countPreservedTerms(
+            [outputById.get(item.id) ?? ""],
+            terms,
+          );
+          if (
+            [...itemExpectedCounts].some(
+              ([term, expected]) =>
+                deficitTerms.has(term) &&
+                (itemActualCounts.get(term) ?? 0) < expected &&
+                replacements.some(
+                  (replacement) =>
+                    replacement.term === term &&
+                    !presentReplacementTokens.has(replacement.openToken),
+                ),
+            )
+          ) {
+            recoveryIds.add(item.id);
+          }
+        }
+        if (recoveryIds.size > 0) {
+          const recovered = await translateBatch(
+            {
+              ...request,
+              instructions: [
+                request.instructions,
+                PRESERVE_MISSING_RECOVERY_INSTRUCTION,
+              ]
+                .filter(Boolean)
+                .join("\n"),
+              items: request.items.filter((item) => recoveryIds.has(item.id)),
+            },
+            signal,
+            onActivity,
+            false,
+          );
+          const recoveredById = new Map(
+            recovered.map((item) => [item.id, item]),
+          );
+          const combinedOutput = restoredOutput.map(
+            (item) => recoveredById.get(item.id) ?? item,
+          );
+          const combinedCounts = countPreservedTerms(
+            combinedOutput.map((item) => item.text),
+            terms,
+          );
+          countMismatch = [...expectedCounts].find(
+            ([term, expected]) => (combinedCounts.get(term) ?? 0) !== expected,
+          );
+          if (countMismatch === undefined) return combinedOutput;
+          for (const [term, count] of combinedCounts) {
+            actualCounts.set(term, count);
+          }
+        }
+      }
+      if (countMismatch !== undefined) {
+        const [term, expected] = countMismatch;
         const actual = actualCounts.get(term) ?? 0;
-        if (actual === expected) continue;
         const unitId = [...replacementsById].find(([, replacements]) =>
           replacements.some((replacement) => replacement.term === term),
         )?.[0];
@@ -465,6 +563,11 @@ export function createPreserveTermsProvider<TContext>(
         );
       }
       return restoredOutput;
+  }
+  return {
+    name: provider.name,
+    translateBatch(request, signal, onActivity) {
+      return translateBatch(request, signal, onActivity);
     },
   };
 }


### PR DESCRIPTION
## 问题

远端自动翻译在 `realtime-webrtc.md` 失败。一个列表批次中原文包含 3 个 `API`，MiniMax 省略了 `ephemeral API key` 中的一个，导致保留词数量由 3 变为 2。

## 修复

- 检测缺失的具体保护标记及其来源单元。
- 仅重新翻译真正遗漏保留词的单元，避免整批重复得到相同结果。
- 保留中文语序导致保护词移动到相邻片段的现有行为，不会重复插入。
- 定向重译仍不满足约束时继续拒绝结果，不会静默写入错误译文。

## 验证

- `pnpm test`（100 项通过）
- `pnpm typecheck`
- `pnpm translate:check`（422 篇完整性检查通过）
- `git diff --check`