### PR TITLE
[AI] fix: 提升翻译 Action 的恢复能力

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -32,7 +32,7 @@ jobs:
       MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}
       TRANSLATION_PROVIDER: ${{ vars.TRANSLATION_PROVIDER }}
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
 
     steps:
       - name: Stop while a translation PR is awaiting review
@@ -94,10 +94,17 @@ jobs:
 
       - name: Translate up to 100 budgeted pages
         if: steps.open-pr.outputs.exists != 'true'
+        id: translate
+        continue-on-error: true
+        timeout-minutes: 160
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: pnpm translate:auto -- --limit 100
+
+      - name: Verify completed translation pages
+        if: ${{ !cancelled() && steps.open-pr.outputs.exists != 'true' && steps.translate.outcome != 'skipped' }}
+        run: pnpm translate:check
 
       - name: Publish the translation branch
         if: steps.open-pr.outputs.exists != 'true'
@@ -187,3 +194,9 @@ jobs:
               pull = response.data;
             }
             core.notice(`Translation PR: ${pull.html_url}`);
+
+      - name: Report translation failure after publishing completed pages
+        if: ${{ !cancelled() && steps.open-pr.outputs.exists != 'true' && steps.translate.outcome == 'failure' }}
+        run: |
+          echo "Translation stopped after the recovery and publishing steps completed."
+          exit 1

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   symlink,
   writeFile,
@@ -437,6 +438,142 @@ test("page retry resumes its checkpoint after batch retries are exhausted", asyn
     assert.deepEqual(pageRetries, [1]);
     assert.equal(run.result.stats.fromCheckpointUnits, 1);
     assert.equal(calls, run.result.stats.uniqueUnits + 1);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("page retry discards a checkpoint that changes protected Markdown structure", async () => {
+  const root = await createFixture("# One\n\nTwo.\n");
+  try {
+    const workspace = await loadTranslationWorkspace(root);
+    let calls = 0;
+    const itemCalls = new Map<string, number>();
+    const provider = defineProvider<MarkdownTranslationContext>({
+      async translateBatch(request) {
+        calls += 1;
+        const item = request.items[0];
+        assert.ok(item);
+        const itemCall = (itemCalls.get(item.text) ?? 0) + 1;
+        itemCalls.set(item.text, itemCall);
+        if (item.text === "One" && itemCall % 2 === 1) {
+          throw new TranslationResponseError(
+            TranslationErrorCode.ResponseQualityRejected,
+            "simulated repeatable quality failure",
+            {
+              details: { issueCode: "translation.test_quality" },
+              retryInstruction: "Return the requested item again.",
+            },
+          );
+        }
+        const hasStructureRecovery = request.instructions?.includes(
+          "不要新增 Markdown",
+        );
+        return [
+          {
+            id: item.id,
+            text:
+              item.text === "Two." && !hasStructureRecovery
+                ? `*${item.text}*`
+                : item.text,
+          },
+        ];
+      },
+    });
+    const retryErrors: unknown[] = [];
+    let retryPolicies = 0;
+    const run = await runTranslationPageWithRetry(workspace, SOURCE_URL, {
+      batchSize: 1,
+      concurrency: 1,
+      pageRetry: {
+        baseDelayMs: 0,
+        jitterMs: 0,
+        maxDelayMs: 0,
+        maxRetries: 1,
+        onRetry: (event) => {
+          retryErrors.push(event.error);
+        },
+        runtime: {
+          random: () => 0,
+          sleep: async () => undefined,
+        },
+      },
+      provider,
+      retryFactory: () => {
+        retryPolicies += 1;
+        const seen = new Set<string>();
+        return {
+          baseDelayMs: 0,
+          jitterMs: 0,
+          maxDelayMs: 0,
+          maxRetries: 1,
+          shouldRetry(error) {
+            if (!(error instanceof TranslationResponseError)) return false;
+            const fingerprint = `${error.code}:${error.message}`;
+            if (seen.has(fingerprint)) return false;
+            seen.add(fingerprint);
+            return true;
+          },
+        };
+      },
+    });
+
+    assert.equal(calls, 6);
+    assert.equal(retryPolicies, 2);
+    assert.equal(run.result.stats.fromCheckpointUnits, 0);
+    assert.equal(run.rendered, "# One\n\nTwo.\n");
+    const checkpoint = JSON.parse(
+      await readFile(join(root, run.checkpointPath), "utf8"),
+    ) as { translations: Array<{ translatedText: string }> };
+    assert.deepEqual(
+      checkpoint.translations.map((item) => item.translatedText),
+      ["One", "Two."],
+    );
+    assert.equal(retryErrors.length, 1);
+    assert.ok(retryErrors[0] instanceof TranslationResponseError);
+    assert.equal(retryErrors[0].code, TranslationErrorCode.ResponseInvalidItem);
+    assert.equal(
+      retryErrors[0].details.issueCode,
+      "translation.markdown_structure_changed",
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("runner removes a poisoned structure checkpoint when retries are exhausted", async () => {
+  const root = await createFixture("# One\n");
+  try {
+    const workspace = await loadTranslationWorkspace(root);
+    const provider = defineProvider<MarkdownTranslationContext>({
+      async translateBatch(request) {
+        return request.items.map((item) => ({
+          id: item.id,
+          text: `*${item.text}*`,
+        }));
+      },
+    });
+
+    await assert.rejects(
+      runTranslationPageWithRetry(workspace, SOURCE_URL, {
+        pageRetry: 0,
+        provider,
+        retry: 0,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof TranslationResponseError);
+        assert.equal(error.code, TranslationErrorCode.ResponseInvalidItem);
+        assert.equal(
+          error.details.issueCode,
+          "translation.markdown_structure_changed",
+        );
+        return true;
+      },
+    );
+    assert.deepEqual(
+      await readdir(join(root, ".cache/translation-checkpoints")),
+      [],
+    );
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -163,7 +163,6 @@ async function runProductionTranslationPage(
   provider: TranslationProvider<MarkdownTranslationContext>,
   commit: boolean,
 ) {
-  const batchRetry = createProductionBatchRetryPolicy();
   const pageRetry: RetryOperationOptions = {
     ...TRANSLATION_PAGE_RETRY_POLICY,
     onRetry: (event) => logRetry("page", page, event),
@@ -174,7 +173,7 @@ async function runProductionTranslationPage(
       onRetry: (event) => logRetry("batch", page, event),
       pageRetry,
       provider,
-      retry: batchRetry,
+      retryFactory: createProductionBatchRetryPolicy,
     });
   } catch (error) {
     throw translationFailure(page, error);

--- a/scripts/translation/markdown-adapter.ts
+++ b/scripts/translation/markdown-adapter.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
 
-import type {
-  DocumentAdapter,
-  TranslationPlan,
-  TranslationResult,
+import {
+  TranslationErrorCode,
+  TranslationResponseError,
+  type DocumentAdapter,
+  type TranslationPlan,
+  type TranslationResult,
 } from "@easy-translate/core";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { frontmatterFromMarkdown } from "mdast-util-frontmatter";
@@ -95,6 +97,24 @@ const GENERATED_CARD_PATTERN =
   /^[ \t]{1,3}\[([^\]\r\n]+)\r?\n(?:[ \t]*\r?\n)+[ \t]{4,}([^\]\r\n]+)\]\((https:\/\/developers\.openai\.com\/[^)\r\n]+)\)[ \t]*$/gmu;
 const GENERATED_CARD_CODE_PATTERN =
   /^([ \t]{4,})[^\]\r\n]+(\]\(https:\/\/developers\.openai\.com\/[^)\r\n]+\))[ \t]*$/u;
+
+export const MARKDOWN_STRUCTURE_ISSUE_CODE =
+  "translation.markdown_structure_changed";
+
+function markdownStructureError(documentId: string): TranslationResponseError {
+  return new TranslationResponseError(
+    TranslationErrorCode.ResponseInvalidItem,
+    "翻译结果改变了 Markdown 受保护结构，已拒绝回填。",
+    {
+      details: {
+        documentId,
+        issueCode: MARKDOWN_STRUCTURE_ISSUE_CODE,
+      },
+      retryInstruction:
+        "只返回对应输入单元的纯文本译文；不要新增 Markdown、HTML、链接、列表、表格或标题语法。",
+    },
+  );
+}
 
 function sha256(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
@@ -733,7 +753,7 @@ export const markdownDocumentAdapter: DocumentAdapter<
     }
     const renderedTree = parseMarkdown(rendered);
     if (structureSignature(renderedTree, rendered) !== state.structureSignature) {
-      throw new Error("翻译结果改变了 Markdown 受保护结构，已拒绝回填。");
+      throw markdownStructureError(state.documentId);
     }
     return rendered;
   },

--- a/scripts/translation/runner.ts
+++ b/scripts/translation/runner.ts
@@ -20,7 +20,9 @@ import {
 } from "node:path";
 
 import {
+  isTranslationCoreError,
   retryOperation,
+  TranslationResponseError,
   translatePlan,
   type RetryOperationOptions,
   type TranslationCheckpoint,
@@ -33,6 +35,7 @@ import {
 
 import {
   containsMarkdownControlCharacter,
+  MARKDOWN_STRUCTURE_ISSUE_CODE,
   markdownDocumentAdapter,
   type MarkdownTranslationContext,
 } from "./markdown-adapter.ts";
@@ -59,6 +62,7 @@ const PLACEHOLDER_PATTERN =
 const LITERAL_BACKTICK_PATTERN = /`+/gu;
 
 export interface TranslationPageRunOptions {
+  additionalInstructions?: string | undefined;
   batchSize?: number | undefined;
   commit?: boolean | undefined;
   concurrency?: number | undefined;
@@ -75,6 +79,7 @@ export type RetriableTranslationPageRunOptions = Omit<
   "useCheckpoint"
 > & {
   pageRetry?: number | RetryOperationOptions | undefined;
+  retryFactory?: (() => number | TranslationRetryPolicy) | undefined;
 };
 
 export interface TranslationPageRunResult {
@@ -310,6 +315,20 @@ async function readOptionalCheckpoint(
       throw new Error(`Checkpoint 不是有效 JSON：${path}`, { cause: error });
     }
     throw error;
+  }
+}
+
+async function removeOptionalCheckpoint(
+  workspace: TranslationWorkspaceSnapshot,
+  path: string,
+): Promise<void> {
+  const root = await realpath(resolve(workspace.repositoryRoot));
+  const absolute = repositoryPath(root, path, "Checkpoint");
+  await assertSafeExistingTarget(root, absolute, "Checkpoint");
+  try {
+    await unlink(absolute);
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) throw error;
   }
 }
 
@@ -610,10 +629,12 @@ export async function runTranslationPage(
   );
   const path = checkpointPath(entry.source.sourceUrl, pagePolicySha256);
   const useCheckpoint = options.useCheckpoint ?? true;
-  const instructions = instructionsForWorkspace(
-    workspace,
-    entry.source.sourceUrl,
-  );
+  const instructions = [
+    instructionsForWorkspace(workspace, entry.source.sourceUrl),
+    options.additionalInstructions?.trim(),
+  ]
+    .filter(Boolean)
+    .join("\n\n");
   let lastReportedRetry: TranslationRetryEvent | undefined;
   const result = await translatePlan(prepared.plan, {
     batchSize: options.batchSize ?? 20,
@@ -684,7 +705,7 @@ export async function runTranslationPageWithRetry(
   sourceUrl: string,
   options: RetriableTranslationPageRunOptions,
 ): Promise<TranslationPageRunResult> {
-  const { pageRetry, ...runOptions } = options;
+  const { pageRetry, retryFactory, ...runOptions } = options;
   const retryOptions: RetryOperationOptions =
     typeof pageRetry === "number"
       ? { maxRetries: pageRetry }
@@ -694,12 +715,45 @@ export async function runTranslationPageWithRetry(
           maxDelayMs: 10_000,
           maxRetries: 1,
         });
+  const path = checkpointPath(
+    sourceUrl,
+    translationPolicySha256ForPage(workspace, sourceUrl),
+  );
+  let structureRetryInstruction = runOptions.additionalInstructions;
   return retryOperation(
-    () =>
-      runTranslationPage(workspace, sourceUrl, {
-        ...runOptions,
-        useCheckpoint: true,
-      }),
+    async () => {
+      try {
+        return await runTranslationPage(workspace, sourceUrl, {
+          ...runOptions,
+          additionalInstructions: structureRetryInstruction,
+          retry: retryFactory?.() ?? runOptions.retry,
+          useCheckpoint: true,
+        });
+      } catch (error) {
+        if (
+          isTranslationCoreError(error) &&
+          error.details.issueCode === MARKDOWN_STRUCTURE_ISSUE_CODE
+        ) {
+          // A structure error is detected only after the complete page has
+          // rendered, so its checkpoint contains the same invalid output.
+          // Remove it even when no retry remains, preventing a later run from
+          // replaying a poisoned checkpoint.
+          await removeOptionalCheckpoint(workspace, path);
+          if (
+            error instanceof TranslationResponseError &&
+            error.retryInstruction
+          ) {
+            structureRetryInstruction = [
+              runOptions.additionalInstructions?.trim(),
+              error.retryInstruction,
+            ]
+              .filter(Boolean)
+              .join("\n\n");
+          }
+        }
+        throw error;
+      }
+    },
     retryOptions,
   );
 }


### PR DESCRIPTION
## 问题

近期 `Translate Chinese docs` 在模型偶发改变 Markdown 受保护结构时，会留下不可复用的完整页 checkpoint 并立即中止；另一次运行在接近完成时触发了 120 分钟 job 超时。

## 修复

- 将 Markdown 结构变化标记为可识别、可纠正的翻译响应错误。
- 结构错误后删除被污染的 checkpoint，并带纠错指令整页重试。
- 每次整页尝试重建有状态批次重试策略，避免跨尝试误判重复错误。
- 翻译步骤失败或达到步骤超时时，先校验并发布此前完成的页面，再让工作流保持失败状态。
- 将 job / 翻译步骤超时调整为 180 / 160 分钟，为收尾发布预留时间。

## 验证

- `pnpm typecheck`
- `pnpm test`（102/102）
- `pnpm translate:check`
- Workflow YAML 解析与 `git diff --check`

关联失败运行：https://github.com/jiahim/OpenAI-API-Chinese/actions/runs/33224928005