### PR TITLE
[AI] test: 避免站点测试依赖固定译文

### DIFF
--- a/apps/web/tests/document-content.test.ts
+++ b/apps/web/tests/document-content.test.ts
@@ -84,9 +84,15 @@ test("renders every document header in title, timestamps, source notice, body or
   assert.ok(titleIndex < timestampsIndex);
   assert.ok(timestampsIndex < sourceNoticeIndex);
   assert.ok(sourceNoticeIndex < bodyIndex);
+  const firstBodyParagraph = /<p>([\\s\\S]*?)<\\/p>/u
+    .exec(html.slice(bodyIndex))?.[1]
+    ?.replace(/<[^>]+>/gu, "")
+    .trim();
+  assert.ok(firstBodyParagraph);
+  assert.ok(firstBodyParagraph.length >= 20);
   assert.equal(
-    html.match(/新南威尔士州国家气象局/gu)?.length,
-    1,
+    html.slice(0, bodyIndex).includes(firstBodyParagraph),
+    false,
     "article body must not be duplicated into the document header",
   );
   assert.match(html, /translation-status-badge/u);

--- a/apps/web/tests/document-content.test.ts
+++ b/apps/web/tests/document-content.test.ts
@@ -84,7 +84,7 @@ test("renders every document header in title, timestamps, source notice, body or
   assert.ok(titleIndex < timestampsIndex);
   assert.ok(timestampsIndex < sourceNoticeIndex);
   assert.ok(sourceNoticeIndex < bodyIndex);
-  const firstBodyParagraph = /<p>([\\s\\S]*?)<\\/p>/u
+  const firstBodyParagraph = /<p>([\s\S]*?)<\/p>/u
     .exec(html.slice(bodyIndex))?.[1]
     ?.replace(/<[^>]+>/gu, "")
     .trim();


### PR DESCRIPTION
## 问题

自动翻译成功生成 100 篇译文后，站点测试仍硬编码旧译文“新南威尔士州国家气象局”。模型将正文改译为 “NSW（National Weather Service）” 后，测试误报正文被重复渲染。

## 修复

- 从实际渲染的正文首段动态提取稳定探针。
- 继续验证该正文内容不会出现在文档头部，不再依赖某一句具体中文译法。

## 验证

- 在翻译 PR #39 的真实 100 篇译文上先复现原测试失败。
- 修复后 `pnpm web:test`：20/20 通过。

关联翻译运行：https://github.com/jiahim/OpenAI-API-Chinese/actions/runs/33224928005
关联翻译 PR：https://github.com/jiahim/OpenAI-API-Chinese/pull/39