### PR TITLE
[AI] fix: 恢复 MiniMax 无效 JSON 翻译批次

### DIFF
--- a/scripts/tests/translation-provider.test.ts
+++ b/scripts/tests/translation-provider.test.ts
@@ -13,6 +13,7 @@ import {
   createLiteralBacktickProvider,
   createLiteralMarkdownDelimiterProvider,
   createInvalidIdRecoveryProvider,
+  createInvalidJsonRecoveryProvider,
   createPreserveTermsProvider,
   createSourceLineBreakNormalizationProvider,
   createTerminologyProvider,
@@ -304,6 +305,112 @@ test("invalid-id provider preserves a terminal single-item failure", async () =>
     }),
     (error: unknown) => error === expected,
   );
+});
+
+test("invalid-JSON provider recursively splits a failed multi-item batch", async () => {
+  const calls: Array<{ instructions: string; size: number }> = [];
+  const provider = defineProvider({
+    async translateBatch(request) {
+      calls.push({
+        instructions: request.instructions ?? "",
+        size: request.items.length,
+      });
+      if (request.items.length > 1) {
+        throw new TranslationResponseError(
+          TranslationErrorCode.ResponseInvalidContainer,
+          "Chat-completions provider did not return valid JSON.",
+        );
+      }
+      return request.items.map((item) => ({
+        id: item.id,
+        text: `译文:${item.text}`,
+      }));
+    },
+  });
+  const recoveryProvider = createInvalidJsonRecoveryProvider(provider);
+  const output = await recoveryProvider.translateBatch({
+    items: [
+      { context: {}, id: "one", text: "one" },
+      { context: {}, id: "two", text: "two" },
+      { context: {}, id: "three", text: "three" },
+    ],
+    targetLanguage: "zh-CN",
+  });
+
+  assert.deepEqual(output, [
+    { id: "one", text: "译文:one" },
+    { id: "two", text: "译文:two" },
+    { id: "three", text: "译文:three" },
+  ]);
+  assert.deepEqual(
+    calls.map((call) => call.size),
+    [3, 2, 1, 1, 1],
+  );
+  for (const call of calls.slice(1)) {
+    assert.match(call.instructions, /Return exactly one JSON object/u);
+  }
+});
+
+test("invalid-JSON provider adds recovery guidance to a terminal failure", async () => {
+  const expected = new TranslationResponseError(
+    TranslationErrorCode.ResponseInvalidContainer,
+    "Chat-completions provider did not return valid JSON.",
+    { retryInstruction: "Keep the original instruction." },
+  );
+  const provider = defineProvider({
+    async translateBatch() {
+      throw expected;
+    },
+  });
+  const recoveryProvider = createInvalidJsonRecoveryProvider(provider);
+
+  await assert.rejects(
+    recoveryProvider.translateBatch({
+      items: [{ context: {}, id: "one", text: "one" }],
+      targetLanguage: "zh-CN",
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof TranslationResponseError);
+      assert.equal(error.code, TranslationErrorCode.ResponseInvalidContainer);
+      assert.equal(error.cause, expected);
+      assert.match(
+        error.retryInstruction ?? "",
+        /Keep the original instruction/u,
+      );
+      assert.match(
+        error.retryInstruction ?? "",
+        /Return exactly one JSON object/u,
+      );
+      return true;
+    },
+  );
+});
+
+test("invalid-JSON provider does not split unrelated container failures", async () => {
+  const expected = new TranslationResponseError(
+    TranslationErrorCode.ResponseInvalidContainer,
+    "Chat-completions provider response has no choices.",
+  );
+  let calls = 0;
+  const provider = defineProvider({
+    async translateBatch() {
+      calls += 1;
+      throw expected;
+    },
+  });
+  const recoveryProvider = createInvalidJsonRecoveryProvider(provider);
+
+  await assert.rejects(
+    recoveryProvider.translateBatch({
+      items: [
+        { context: {}, id: "one", text: "one" },
+        { context: {}, id: "two", text: "two" },
+      ],
+      targetLanguage: "zh-CN",
+    }),
+    (error: unknown) => error === expected,
+  );
+  assert.equal(calls, 1);
 });
 
 test("source line-break provider flattens matching translated layout breaks", async () => {

--- a/scripts/translation/provider.ts
+++ b/scripts/translation/provider.ts
@@ -59,6 +59,13 @@ const LITERAL_BACKTICK_INSTRUCTION =
 const INVALID_ID_RECOVERY_INSTRUCTION =
   "INVALID ID RECOVERY: This request is a smaller recovery sub-batch. " +
   "Return every requested id exactly once, even when adjacent text fragments form one sentence.";
+const INVALID_JSON_RECOVERY_INSTRUCTION =
+  "INVALID JSON RECOVERY: This request is a smaller recovery sub-batch. " +
+  "Return exactly one JSON object with no prose, reasoning, or Markdown code fences. " +
+  'Use exactly this shape: {"translations":[{"id":"...","text":"..."}]}. ' +
+  "Return every requested id exactly once.";
+const CHAT_COMPLETIONS_INVALID_JSON_MESSAGE =
+  "Chat-completions provider did not return valid JSON.";
 const LITERAL_BACKTICK_PATTERN = /`+/gu;
 const LITERAL_MARKDOWN_DELIMITER_INSTRUCTION =
   "{{ET_MD_*}} tokens represent protected literal Markdown emphasis or strikethrough delimiter runs. " +
@@ -615,6 +622,60 @@ export function createInvalidIdRecoveryProvider<TContext>(
   return { name: provider.name, translateBatch };
 }
 
+export function createInvalidJsonRecoveryProvider<TContext>(
+  provider: TranslationProvider<TContext>,
+): TranslationProvider<TContext> {
+  async function translateBatch(
+    request: TranslationBatchRequest<TContext>,
+    signal?: AbortSignal,
+    onActivity?: Parameters<TranslationProvider<TContext>["translateBatch"]>[2],
+  ): Promise<TranslationOutputItem[]> {
+    try {
+      return await provider.translateBatch(request, signal, onActivity);
+    } catch (error) {
+      const invalidJson =
+        error instanceof TranslationResponseError &&
+        error.code === TranslationErrorCode.ResponseInvalidContainer &&
+        error.message === CHAT_COMPLETIONS_INVALID_JSON_MESSAGE;
+      if (!invalidJson) throw error;
+
+      const instructions = [
+        request.instructions,
+        INVALID_JSON_RECOVERY_INSTRUCTION,
+      ]
+        .filter(Boolean)
+        .join("\n");
+      if (request.items.length < 2) {
+        throw new TranslationResponseError(error.code, error.message, {
+          cause: error,
+          details: error.details,
+          retryInstruction: [
+            error.retryInstruction,
+            INVALID_JSON_RECOVERY_INSTRUCTION,
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        });
+      }
+
+      const midpoint = Math.ceil(request.items.length / 2);
+      const left = await translateBatch(
+        { ...request, instructions, items: request.items.slice(0, midpoint) },
+        signal,
+        onActivity,
+      );
+      const right = await translateBatch(
+        { ...request, instructions, items: request.items.slice(midpoint) },
+        signal,
+        onActivity,
+      );
+      return [...left, ...right];
+    }
+  }
+
+  return { name: provider.name, translateBatch };
+}
+
 export function createTerminologyProvider<TContext>(
   provider: TranslationProvider<TContext>,
   preserveTerms: readonly string[],
@@ -951,8 +1012,8 @@ export function createConfiguredProvider(
         createLiteralBacktickProvider(
           createPreserveTermsProvider(
             createTerminologyProvider(
-              createInvalidIdRecoveryProvider(
-                provider,
+              createInvalidJsonRecoveryProvider(
+                createInvalidIdRecoveryProvider(provider),
               ),
               preserveTerms,
               terminology,


### PR DESCRIPTION
## 问题

翻译 Action 在处理较大的翻译批次时，MiniMax-M3 偶发返回无法解析的 JSON。原有批次重试和页面重试会重复发送同一批内容，最终仍以 `response.invalid_container` 失败。

失败任务：https://github.com/jiahim/OpenAI-API-Chinese/actions/runs/33298954251/job/99223376760

## 修复

- 仅针对 chat-completions 返回无效 JSON 的精确错误启用恢复，避免其他响应错误产生额外请求。
- 自动把失败批次递归拆成更小的子批次后重新翻译。
- 子批次缩至单条仍失败时，为下一次引擎重试追加严格 JSON 格式指令。
- 保留现有 ID 完整性恢复、术语保护与检查逻辑。

## 验证

- `pnpm test`：105 项通过
- `pnpm typecheck`：通过
- `pnpm translate:check`：通过
- `git diff --check`：通过