### PR TITLE
[AI] fix: 支持超长页面语义分批翻译

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -92,7 +92,7 @@ jobs:
           pnpm test
           pnpm translate:check
 
-      - name: Translate up to 100 budgeted pages
+      - name: Translate up to 100 pages in semantic batches
         if: steps.open-pr.outputs.exists != 'true'
         id: translate
         continue-on-error: true
@@ -158,7 +158,7 @@ jobs:
             const body = [
               "## 自动中文翻译",
               "",
-              "本 PR 由受信任的 `main` 工作流使用环境配置的大模型供应商自动生成，每次最多处理 100 篇受预算约束的页面。",
+              "本 PR 由受信任的 `main` 工作流使用环境配置的大模型供应商自动生成，每次最多处理 100 篇页面；长页面由 easy-translate 按 Markdown 语义单元分批翻译。",
               "",
               "### 文件",
               "",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 └── .github/workflows/
     ├── ci.yml                # PR、main 与手动触发的质量门禁
     ├── sync-docs.yml         # 每天检查并创建官方更新 PR
-    └── translate-docs.yml    # 受预算约束的批量自动翻译 PR
+    └── translate-docs.yml    # 按语义分批的自动翻译 PR
 ```
 
 英文文件严格按照官网 URL 的路径保存。例如：
@@ -78,11 +78,11 @@ GitHub Actions 每天北京时间 00:00 读取官方 `llms.txt` 索引、运行�
 
 在 **Environment secrets** 中配置 `MINIMAX_API_KEY` 或 `DEEPSEEK_API_KEY`。只有一个 Key 时会自动选择对应供应商；仅有 MiniMax Key 时默认选择国内站 `minimax-cn`。同时存在两个 Key 时必须在 **Environment variables** 中设置 `TRANSLATION_PROVIDER`，值只能是上表中的键名。模型可通过同处的 `MINIMAX_MODEL` 或 `DEEPSEEK_MODEL` 切换，无需修改仓库或创建 PR。MiniMax 国内站 Plan 应使用 `minimax-cn`；国内站与国际站的 Key 和额度按各自接口生效，不应混用。
 
-运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译 100 篇页面，每篇不超过 20,000 个源字符，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
+运行时解析出的实际 provider/model 会进入翻译策略指纹。每轮最多翻译 100 篇页面；长页面先由 Markdown adapter 拆成可安全回填的语义单元，再由 `easy-translate` 按每批最多 20 个单元、4,000 个源字符组织模型请求，并通过 `automation/translate-openai-docs` 创建一个 PR。已有翻译 PR 等待审核时不会继续调用模型。自动选择先按 stale/missing 状态维护既有译文，再在同一状态内按 `scripts/translation/priority.zh-CN.json` 的核心文档顺序处理，未列入清单的页面保持稳定路径排序。术语表中的 `preserve` 项会在请求前替换为可恢复占位符；每个成功批次都会写入 checkpoint，单批请求耗尽有限重试后，页面还会基于 checkpoint 额外恢复一次，认证、配置和完整性错误不会盲目重试。
 
 仓库必须在 **Settings → Actions → General → Workflow permissions** 中启用 **Allow GitHub Actions to create and approve pull requests**。`main` 的 Ruleset 可以因此保持空 bypass，并要求所有更新通过 PR 和 `Quality gate`。PR 标题必须以 `[AI] ` 或 `[Human] ` 标明来源，其中 `codex/` 与 `automation/` 分支强制使用 `[AI] `。
 
-`translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端按优先级选择最多 100 篇受预算约束的页面；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。
+`translate:status` 离线汇总全部页面的增量状态，`translate:check` 额外拒绝目标文件缺失、未登记或与 manifest 不一致；`translate:plan` 按自动队列优先级只读列出下一轮可翻译或阻塞的页面。`translate:simulate` 使用 Echo/Fake Provider 执行无 key、无写入闭环。`translate:run` 用于本地精确单篇翻译，`translate:auto` 为远端按优先级选择最多 100 篇页面并按语义单元分批处理；人工润色后用 `translate:review` 收录目标 SHA 并标记 `reviewed`。完整翻译设计见 [`docs/translation-design.md`](docs/translation-design.md)。
 
 人工校对中可复用的固定译法应进入术语表，通用表达要求应进入翻译提示词；只适用于单篇文档的上下文、歧义或官方原文勘误记录在 `scripts/translation/review-notes.zh-CN.json`。页面级备注会自动加入该页翻译请求和策略 SHA，仅让对应页面进入 `stale-policy`，不会触发全站重翻。
 

--- a/docs/translation-design.md
+++ b/docs/translation-design.md
@@ -6,7 +6,7 @@
 
 本仓库负责 Markdown 结构保护、英文/中文路径映射、术语与提示词、翻译 manifest、增量选择和文档级质量门。批处理、并发、Provider 输出校验、重试、checkpoint、进度和取消复用已发布的 `@easy-translate/core`；OpenAI 与兼容接口复用 `@easy-translate/providers`。本仓库不复制 Provider 或通用翻译引擎。
 
-当前实现提供离线的 `translate:status`、`translate:check`、`translate:plan`、Markdown adapter 和单篇 `translate:simulate`；另提供严格限定单篇的 `translate:run`，以及供受信任远端 workflow 使用的受预算约束批量 `translate:auto`，两者通过 `@easy-translate/providers` 接入配置指定的 DeepSeek 或 MiniMax。simulate 不调用模型、不读取 API key，也不写入 `docs/zh`。
+当前实现提供离线的 `translate:status`、`translate:check`、`translate:plan`、Markdown adapter 和单篇 `translate:simulate`；另提供严格限定单篇的 `translate:run`，以及供受信任远端 workflow 使用的语义分批 `translate:auto`，两者通过 `@easy-translate/providers` 接入配置指定的 DeepSeek 或 MiniMax。simulate 不调用模型、不读取 API key，也不写入 `docs/zh`。
 
 ## 目录与持久化契约
 
@@ -98,7 +98,7 @@ Runner 只接受 Planner 判定为 `pending`、`stale-source`、`stale-policy` �
 2. **Markdown adapter（已完成）**：source-position 提取/还原、保护不变量、fixture 测试，并对齐 `@easy-translate/core` 的 `DocumentAdapter`。
 3. **本地翻译执行器（已完成）**：Core、checkpoint、单篇选择、质量策略、DeepSeek profile 和显式原子提交。
 4. **质量与人工校对（已完成基础闭环）**：结构检查、术语检查、显式 review 收录和 stale 传播；后续补充未登记文件的 adopt 流程。
-5. **自动翻译 PR（已完成首轮生产验收）**：英文变化合入 `main` 后立即触发，并每天补充执行；每轮最多 100 篇、单篇 20,000 源字符上限、单一待审核 PR，继续服从 `Quality gate` 和 `main` Ruleset。
+5. **自动翻译 PR（已完成首轮生产验收）**：英文变化合入 `main` 后立即触发，并每天补充执行；每轮最多 100 篇，长页面由 Markdown adapter 生成语义单元，再由 `easy-translate` 按每批最多 20 个单元、4,000 个源字符执行并逐批保存 checkpoint；维持单一待审核 PR，继续服从 `Quality gate` 和 `main` Ruleset。
 6. **内容积累（当前）**：按核心文档优先级积累中文页面，观察流水线稳定性后再扩大单轮吞吐。
 
 任何阶段都不得把模型凭据写入仓库，也不得直接 push `main`。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -141,7 +141,7 @@ pnpm translate:review -- --match guides/agents/quickstart.md --limit 1
 
 `.github/workflows/translate-docs.yml` 在 `docs/en` 变更合入 `main` 后触发，并每天北京时间 01:00（UTC 17:00）补充运行。工作流只检出受信任的 `main`，在类型检查、测试和 `translate:check` 全部通过后，才把 `translation-production` 环境中的 `DEEPSEEK_API_KEY` 注入翻译步骤。
 
-`translate:auto -- --limit 100` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多 100 篇，每篇都不超过 20,000 个源字符。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
+`translate:auto -- --limit 100` 按 `stale-source`、`stale-policy`、`missing-target`、`pending` 的顺序选择页面；同一状态内按 `translation/priority.zh-CN.json` 的 `sourcePaths` 顺序优先处理模型、API 概览、文本生成、流式输出、工具、Realtime、Agents 和生产最佳实践等核心文档，未列入清单的页面按稳定路径回退。`translate:plan` 使用相同顺序展示队列。每轮最多 100 篇，不限制整页源字符数；Markdown adapter 先生成可回填的语义单元，`easy-translate` 再按每批最多 20 个单元、4,000 个源字符调用模型，并在每个成功批次后保存 checkpoint。生成结果只推送到 `automation/translate-openai-docs` 并创建一个 PR。已有翻译 PR 时工作流直接停止，避免重复调用模型和堆积未审核译文。
 
 生产翻译采用分层恢复：术语表的 `preserve` 项在发送前按最长匹配包裹为唯一的成对保护标记，标记内保留可见原词；模型复制标记、去掉外壳或改写成对标记内文本时，返回后都会恢复原词，任何保护标记残留都会被拒绝。指定译法按完整单词或短语匹配，并忽略已整体保留的产品名，避免将 `Agent` 误匹配到 `Agents SDK`。当一个 Markdown 语义块被链接、图片、代码或换行拆成多个翻译单元时，术语表仍随完整批次发送给模型，但质量门不再要求每个片段各自包含目标术语，避免中文调整语序后被误判。每个批次对格式、质量、网络、限流、超时和服务端临时错误最多重试 2 次，并记录页面、单元、原因和退避时间；同一质量错误再次出现时提前终止。批次仍失败时，只有格式响应错误和可重试 Provider 错误会在等待 10–12 秒后从 checkpoint 做一次页面恢复，质量错误不再整页重试。认证失败、无效请求、配置、路径和仓库完整性错误不会重试。
 

--- a/scripts/tests/markdown-adapter.test.ts
+++ b/scripts/tests/markdown-adapter.test.ts
@@ -191,6 +191,41 @@ test("multiline list and quote source ranges never consume continuation markers"
   );
 });
 
+test("bounded semantic ranges preserve whitespace outside translated fragments", async () => {
+  const source = "# a   b\tc. d\n\n![   abcdefgh   ](chart.png)\n";
+  const prepared = await markdownDocumentAdapter.prepare({
+    content: source,
+    id: "fixture.md",
+    maxUnitCharacters: 4,
+  });
+  const rendered = await markdownDocumentAdapter.render(
+    prepared.formatState,
+    result(new Map(prepared.plan.units.map((unit) => [unit.id, unit.text]))),
+  );
+
+  assert.ok(prepared.plan.units.every((unit) => unit.text.length <= 4));
+  assert.equal(rendered, source);
+});
+
+test("bounded semantic ranges never split an oversized grapheme", async () => {
+  await assert.rejects(
+    markdownDocumentAdapter.prepare({
+      content: "# a\u0301b\n",
+      id: "combining.md",
+      maxUnitCharacters: 1,
+    }),
+    /Unicode 字素/u,
+  );
+  await assert.rejects(
+    markdownDocumentAdapter.prepare({
+      content: "# 👨‍👩‍👧‍👦 family\n",
+      id: "emoji.md",
+      maxUnitCharacters: 4,
+    }),
+    /Unicode 字素/u,
+  );
+});
+
 test("generated multiline navigation cards translate labels and descriptions", async () => {
   const source = `  [Agent definitions
 

--- a/scripts/tests/translation-auto.test.ts
+++ b/scripts/tests/translation-auto.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+const REPOSITORY_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const SOURCE_URL = "https://developers.openai.com/api/docs/long-page.md";
+const SOURCE_PATH = "docs/en/api/docs/long-page.md";
+const TARGET_PATH = "docs/zh/api/docs/long-page.md";
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+async function createCliFixture(source: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "translation-auto-"));
+  await mkdir(join(root, "scripts"), { recursive: true });
+  await cp(
+    join(REPOSITORY_ROOT, "scripts/translate-docs.ts"),
+    join(root, "scripts/translate-docs.ts"),
+  );
+  await cp(
+    join(REPOSITORY_ROOT, "scripts/translation"),
+    join(root, "scripts/translation"),
+    { recursive: true },
+  );
+  await symlink(join(REPOSITORY_ROOT, "node_modules"), join(root, "node_modules"));
+  await mkdir(join(root, "docs/en/api/docs"), { recursive: true });
+  await writeFile(join(root, SOURCE_PATH), source);
+  await writeFile(
+    join(root, "docs/en/.source-manifest.json"),
+    JSON.stringify({
+      indexes: {},
+      pages: {
+        [SOURCE_URL]: {
+          localPath: SOURCE_PATH,
+          section: "guides",
+          sha256: sha256(source),
+          sourceUrl: SOURCE_URL,
+          status: "active",
+        },
+      },
+      schemaVersion: 1,
+    }),
+  );
+  await writeFile(
+    join(root, "scripts/translation.config.json"),
+    JSON.stringify({
+      glossaryPath: "scripts/translation/glossary.zh-CN.json",
+      priorityPath: "scripts/translation/priority.zh-CN.json",
+      promptPath: "scripts/translation/prompt.zh-CN.md",
+      provider: {
+        apiKeyEnv: "DEEPSEEK_API_KEY",
+        id: "deepseek",
+        model: "deepseek-chat",
+      },
+      reviewNotesPath: "scripts/translation/review-notes.zh-CN.json",
+      schemaVersion: 2,
+      sourceManifestPath: "docs/en/.source-manifest.json",
+      sourceRoot: "docs/en",
+      targetLanguage: "zh-CN",
+      targetRoot: "docs/zh",
+      translationManifestPath: "docs/zh/.translation-manifest.json",
+    }),
+  );
+  await writeFile(
+    join(root, "scripts/translation/glossary.zh-CN.json"),
+    JSON.stringify({ preserve: [], schemaVersion: 1, terms: {} }),
+  );
+  await writeFile(
+    join(root, "scripts/translation/priority.zh-CN.json"),
+    JSON.stringify({ schemaVersion: 1, sourcePaths: [SOURCE_PATH] }),
+  );
+  await writeFile(
+    join(root, "scripts/translation/prompt.zh-CN.md"),
+    "Translate accurately.",
+  );
+  await writeFile(
+    join(root, "scripts/translation/review-notes.zh-CN.json"),
+    JSON.stringify({ pages: {}, schemaVersion: 1 }),
+  );
+  return root;
+}
+
+test("auto translates a page larger than 20,000 characters through semantic batches", async () => {
+  const source = `# Hello\n\n\`\`\`text\n${"x".repeat(21_000)}\n\`\`\`\n`;
+  const root = await createCliFixture(source);
+  const originalFetch = globalThis.fetch;
+  const originalApiKey = process.env.DEEPSEEK_API_KEY;
+  let providerCalls = 0;
+  globalThis.fetch = (async () => {
+    providerCalls += 1;
+    return Response.json({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              translations: [
+                { id: "markdown-1-2-7", text: "你好" },
+              ],
+            }),
+          },
+        },
+      ],
+    });
+  }) as typeof fetch;
+  process.env.DEEPSEEK_API_KEY = "test-secret";
+
+  try {
+    const moduleUrl = `${pathToFileURL(join(root, "scripts/translate-docs.ts")).href}?${randomUUID()}`;
+    const translationCli = await import(moduleUrl);
+    const exitCode = await translationCli.main([
+      "auto",
+      "--config",
+      "scripts/translation.config.json",
+      "--limit",
+      "100",
+    ]);
+    const translated = await readFile(join(root, TARGET_PATH), "utf8").catch(
+      () => undefined,
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(providerCalls, 1);
+    assert.equal(translated, source.replace("Hello", "你好"));
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalApiKey === undefined) {
+      delete process.env.DEEPSEEK_API_KEY;
+    } else {
+      process.env.DEEPSEEK_API_KEY = originalApiKey;
+    }
+    await rm(root, { force: true, recursive: true });
+  }
+});

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -259,36 +259,48 @@ test("runner accumulates manifest records across a batch using one workspace sna
 });
 
 test("runner sends long Markdown prose through bounded semantic batches", async () => {
-  const source = Array.from(
-    { length: 60 },
-    (_, index) => `Paragraph ${index + 1}: ${"word ".repeat(80).trim()}.`,
-  ).join("\n\n");
+  const source = [
+    `# ${"a".repeat(5_000)}`,
+    ...Array.from(
+      { length: 60 },
+      (_, index) => `Paragraph ${index + 1}: ${"word ".repeat(80).trim()}.`,
+    ),
+    ...Array.from({ length: 25 }, (_, index) => `Short ${index + 1}.`),
+  ].join("\n\n");
   assert.ok(source.length > 20_000);
   const root = await createFixture(source);
   try {
     const workspace = await loadTranslationWorkspace(root);
-    const batchCharacters: number[] = [];
+    const batches: Array<{ characters: number; items: number; maxItem: number }> = [];
     const provider = defineProvider<MarkdownTranslationContext>({
       async translateBatch(request) {
-        batchCharacters.push(
-          request.items.reduce((sum, item) => sum + item.text.length, 0),
-        );
+        batches.push({
+          characters: request.items.reduce(
+            (sum, item) => sum + item.text.length,
+            0,
+          ),
+          items: request.items.length,
+          maxItem: request.items.reduce(
+            (maximum, item) => Math.max(maximum, item.text.length),
+            0,
+          ),
+        });
         return request.items.map((item) => ({ id: item.id, text: item.text }));
       },
     });
 
     const run = await runTranslationPage(workspace, SOURCE_URL, {
-      batchSize: 20,
       commit: false,
       concurrency: 1,
-      maxBatchCharacters: 4_000,
       provider,
       retry: 0,
       useCheckpoint: false,
     });
 
-    assert.ok(batchCharacters.length > 1);
-    assert.ok(batchCharacters.every((characters) => characters <= 4_000));
+    assert.ok(batches.length > 1);
+    assert.ok(batches.every((batch) => batch.characters <= 4_000));
+    assert.ok(batches.every((batch) => batch.items <= 20));
+    assert.ok(batches.every((batch) => batch.maxItem <= 4_000));
     assert.equal(run.rendered, source);
   } finally {
     await rm(root, { force: true, recursive: true });

--- a/scripts/tests/translation-runner.test.ts
+++ b/scripts/tests/translation-runner.test.ts
@@ -258,6 +258,43 @@ test("runner accumulates manifest records across a batch using one workspace sna
   }
 });
 
+test("runner sends long Markdown prose through bounded semantic batches", async () => {
+  const source = Array.from(
+    { length: 60 },
+    (_, index) => `Paragraph ${index + 1}: ${"word ".repeat(80).trim()}.`,
+  ).join("\n\n");
+  assert.ok(source.length > 20_000);
+  const root = await createFixture(source);
+  try {
+    const workspace = await loadTranslationWorkspace(root);
+    const batchCharacters: number[] = [];
+    const provider = defineProvider<MarkdownTranslationContext>({
+      async translateBatch(request) {
+        batchCharacters.push(
+          request.items.reduce((sum, item) => sum + item.text.length, 0),
+        );
+        return request.items.map((item) => ({ id: item.id, text: item.text }));
+      },
+    });
+
+    const run = await runTranslationPage(workspace, SOURCE_URL, {
+      batchSize: 20,
+      commit: false,
+      concurrency: 1,
+      maxBatchCharacters: 4_000,
+      provider,
+      retry: 0,
+      useCheckpoint: false,
+    });
+
+    assert.ok(batchCharacters.length > 1);
+    assert.ok(batchCharacters.every((characters) => characters <= 4_000));
+    assert.equal(run.rendered, source);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
 test("review adopts an intentional target edit and records reviewed status", async () => {
   const root = await createFixture();
   try {

--- a/scripts/translate-docs.ts
+++ b/scripts/translate-docs.ts
@@ -16,7 +16,6 @@ import {
 
 import {
   loadTranslationWorkspace,
-  readTranslationWorkspaceFile,
 } from "./translation/planner.ts";
 import {
   reviewTranslationPage,
@@ -57,7 +56,6 @@ type SourcedTranslationPageInspection = TranslationPageInspection & {
 
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_CONFIG_PATH = "scripts/translation.config.json";
-const AUTO_MAX_SOURCE_CHARACTERS = 20_000;
 const AUTO_PAGE_LIMIT = 100;
 const TRANSLATION_BATCH_RETRY_POLICY = {
   baseDelayMs: 1_000,
@@ -491,35 +489,18 @@ async function auto(
   options: CliOptions,
 ): Promise<void> {
   const priority = await loadTranslationPriorityConfig(workspace);
-  const selected: Array<{
-    entry: SourcedTranslationPageInspection;
-    sourceCharacters: number;
-  }> = [];
+  const selected: SourcedTranslationPageInspection[] = [];
   for (const entry of automaticTranslationCandidates(
     workspace.entries,
     options.section,
     priority.sourcePaths,
   )) {
     if (!entry.source) continue;
-    const source = await readTranslationWorkspaceFile(
-      workspace,
-      entry.source.sourcePath,
-      "自动翻译英文页面",
-    );
-    if (source.length <= AUTO_MAX_SOURCE_CHARACTERS) {
-      selected.push({
-        entry: { ...entry, source: entry.source },
-        sourceCharacters: source.length,
-      });
-      if (selected.length === options.limit) break;
-      continue;
-    }
-    console.log(
-      `跳过超出自动预算的页面：${entry.source.sourcePath} (${source.length} > ${AUTO_MAX_SOURCE_CHARACTERS})`,
-    );
+    selected.push({ ...entry, source: entry.source });
+    if (selected.length === options.limit) break;
   }
   if (selected.length === 0) {
-    console.log("自动翻译：没有符合状态与字符预算的页面。");
+    console.log("自动翻译：没有待翻译页面。");
     return;
   }
   const provider = createConfiguredProvider(
@@ -532,23 +513,22 @@ async function auto(
     const result = await runProductionTranslationPage(
       workspace,
       {
-        sourcePath: selection.entry.source.sourcePath,
-        sourceUrl: selection.entry.source.sourceUrl,
-        targetPath: selection.entry.targetPath,
+        sourcePath: selection.source.sourcePath,
+        sourceUrl: selection.source.sourceUrl,
+        targetPath: selection.targetPath,
       },
       provider,
       true,
     );
     console.log(`自动翻译页面：${result.sourceUrl}`);
     console.log(`page=${index + 1}/${selected.length}`);
-    console.log(`state=${selection.entry.state}`);
+    console.log(`state=${selection.state}`);
     const priorityIndex = priority.sourcePaths.indexOf(
-      selection.entry.source.sourcePath,
+      selection.source.sourcePath,
     );
     console.log(`priority=${priorityIndex >= 0 ? priorityIndex + 1 : "fallback"}`);
-    console.log(`source=${selection.entry.source.sourcePath}`);
+    console.log(`source=${selection.source.sourcePath}`);
     console.log(`target=${result.targetPath}`);
-    console.log(`sourceCharacters=${selection.sourceCharacters}`);
     console.log(`units=${result.result.stats.uniqueUnits}`);
     console.log(`characters=${result.result.stats.characters}`);
     console.log("写入：是（译文及 manifest，reviewStatus=machine）");

--- a/scripts/translation/markdown-adapter.ts
+++ b/scripts/translation/markdown-adapter.ts
@@ -39,6 +39,7 @@ interface MarkdownNode {
 export interface MarkdownDocumentInput {
   content: string;
   id: string;
+  maxUnitCharacters?: number | undefined;
   sourceHash?: string | undefined;
 }
 
@@ -441,6 +442,136 @@ function textNodeRanges(
   return ranges;
 }
 
+const GRAPHEME_SEGMENTER = new Intl.Segmenter("en", {
+  granularity: "grapheme",
+});
+
+interface MarkdownGraphemeRange {
+  end: number;
+  start: number;
+  text: string;
+}
+
+function graphemeRanges(
+  source: string,
+  start: number,
+  end: number,
+): MarkdownGraphemeRange[] {
+  return Array.from(
+    GRAPHEME_SEGMENTER.segment(source.slice(start, end)),
+    ({ index, segment }) => ({
+      end: start + index + segment.length,
+      start: start + index,
+      text: segment,
+    }),
+  );
+}
+
+function splitPendingRange(
+  source: string,
+  range: PendingMarkdownSourceRange,
+  maxUnitCharacters: number,
+): PendingMarkdownSourceRange[] {
+  const graphemes = graphemeRanges(source, range.start, range.end);
+  let first = 0;
+  while (
+    first < graphemes.length &&
+    /^\s+$/u.test(graphemes[first]?.text ?? "")
+  ) {
+    first += 1;
+  }
+  let lastExclusive = graphemes.length;
+  while (
+    lastExclusive > first &&
+    /^\s+$/u.test(graphemes[lastExclusive - 1]?.text ?? "")
+  ) {
+    lastExclusive -= 1;
+  }
+  if (first === lastExclusive) return [];
+  const contentStart = graphemes[first]?.start ?? range.start;
+  const contentEnd = graphemes[lastExclusive - 1]?.end ?? range.end;
+  if (contentEnd - contentStart <= maxUnitCharacters) {
+    return [
+      {
+        ...range,
+        end: contentEnd,
+        sourceText: source.slice(contentStart, contentEnd),
+        start: contentStart,
+      },
+    ];
+  }
+  const split: PendingMarkdownSourceRange[] = [];
+  let current = first;
+  while (current < lastExclusive) {
+    const start = graphemes[current]?.start;
+    if (start === undefined) break;
+    let maximumExclusive = current;
+    while (
+      maximumExclusive < lastExclusive &&
+      (graphemes[maximumExclusive]?.end ?? start) - start <=
+        maxUnitCharacters
+    ) {
+      maximumExclusive += 1;
+    }
+    if (maximumExclusive === current) {
+      throw new Error(
+        `Markdown 翻译单元包含超过 ${maxUnitCharacters} 个源字符的单个 Unicode 字素。`,
+      );
+    }
+    if (maximumExclusive === lastExclusive) {
+      split.push({
+        ...range,
+        end: contentEnd,
+        sourceText: source.slice(start, contentEnd),
+        start,
+      });
+      break;
+    }
+
+    let end = graphemes[maximumExclusive - 1]?.end ?? start;
+    let next = maximumExclusive;
+    for (let index = maximumExclusive - 1; index >= current; index -= 1) {
+      const grapheme = graphemes[index];
+      if (!grapheme || !/[.!?;:\u3002\uff01\uff1f\uff1b\uff1a]/u.test(grapheme.text)) {
+        continue;
+      }
+      end = grapheme.end;
+      next = index + 1;
+      break;
+    }
+    if (next === maximumExclusive) {
+      for (let index = maximumExclusive - 1; index > current; index -= 1) {
+        const grapheme = graphemes[index];
+        if (!grapheme || !/^\s+$/u.test(grapheme.text)) continue;
+        let runStart = index;
+        while (
+          runStart > current &&
+          /^\s+$/u.test(graphemes[runStart - 1]?.text ?? "")
+        ) {
+          runStart -= 1;
+        }
+        end = graphemes[runStart]?.start ?? end;
+        next = index + 1;
+        break;
+      }
+    }
+    split.push({
+      ...range,
+      end,
+      sourceText: source.slice(start, end),
+      start,
+    });
+    while (
+      next < lastExclusive &&
+      /^\s+$/u.test(graphemes[next]?.text ?? "")
+    ) {
+      next += 1;
+    }
+    current = next;
+  }
+  return split;
+}
+
 function generatedCardTextRanges(
   source: string,
 ): Array<{ end: number; groupKey: string; start: number }> {
@@ -492,7 +623,11 @@ function imageAltRange(node: MarkdownNode, source: string): { end: number; start
   throw new Error("无法定位图片 alt 的 source range。");
 }
 
-function collectRanges(root: MarkdownNode, source: string): MarkdownSourceRange[] {
+function collectRanges(
+  root: MarkdownNode,
+  source: string,
+  maxUnitCharacters: number,
+): MarkdownSourceRange[] {
   const generatedCardRanges = generatedCardTextRanges(source);
   const pending: PendingMarkdownSourceRange[] = generatedCardRanges.map(
     ({ groupKey, ...range }) => ({
@@ -546,12 +681,15 @@ function collectRanges(root: MarkdownNode, source: string): MarkdownSourceRange[
   }
 
   visit(root, []);
-  pending.sort((left, right) => left.start - right.start || left.end - right.end);
+  const bounded = pending.flatMap((range) =>
+    splitPendingRange(source, range, maxUnitCharacters),
+  );
+  bounded.sort((left, right) => left.start - right.start || left.end - right.end);
   const groupSizes = new Map<string, number>();
-  for (const range of pending) {
+  for (const range of bounded) {
     groupSizes.set(range.groupKey, (groupSizes.get(range.groupKey) ?? 0) + 1);
   }
-  return pending.map(({ groupKey, ...range }, index) => ({
+  return bounded.map(({ groupKey, ...range }, index) => ({
     ...range,
     fragmented: (groupSizes.get(groupKey) ?? 0) > 1,
     id: `markdown-${index + 1}-${range.start}-${range.end}`,
@@ -668,7 +806,10 @@ export const markdownDocumentAdapter: DocumentAdapter<
       typeof input.id !== "string" ||
       input.id.trim() !== input.id ||
       !input.id ||
-      typeof input.content !== "string"
+      typeof input.content !== "string" ||
+      (input.maxUnitCharacters !== undefined &&
+        (!Number.isSafeInteger(input.maxUnitCharacters) ||
+          input.maxUnitCharacters <= 0))
     ) {
       throw new Error("Markdown 输入必须包含有效 id 和 content。");
     }
@@ -677,7 +818,11 @@ export const markdownDocumentAdapter: DocumentAdapter<
       throw new Error("Markdown 输入的 sourceHash 与 content 不匹配。");
     }
     const tree = parseMarkdown(input.content);
-    const ranges = collectRanges(tree, input.content);
+    const ranges = collectRanges(
+      tree,
+      input.content,
+      input.maxUnitCharacters ?? Number.MAX_SAFE_INTEGER,
+    );
     const units: TranslationPlan<MarkdownTranslationContext>["units"] = ranges.map(
       ({ id, sourceText, ...context }) => ({
         // Keep adjacent prose and inline link labels together so the provider

--- a/scripts/translation/runner.ts
+++ b/scripts/translation/runner.ts
@@ -618,9 +618,11 @@ export async function runTranslationPage(
   if (sha256(source) !== entry.source.sha256) {
     throw new Error(`英文页面 SHA 在执行前发生变化：${entry.source.sourcePath}`);
   }
+  const maxBatchCharacters = options.maxBatchCharacters ?? 4_000;
   const prepared = await markdownDocumentAdapter.prepare({
     content: source,
     id: entry.source.sourceUrl,
+    maxUnitCharacters: maxBatchCharacters,
     sourceHash: entry.source.sha256,
   });
   const pagePolicySha256 = translationPolicySha256ForPage(
@@ -643,7 +645,7 @@ export async function runTranslationPage(
       : undefined,
     concurrency: options.concurrency ?? 1,
     instructions,
-    maxBatchCharacters: options.maxBatchCharacters ?? 4_000,
+    maxBatchCharacters,
     onCheckpoint: useCheckpoint
       ? async (checkpoint) =>
           atomicWriteRepositoryFile(


### PR DESCRIPTION
## 变更

- 移除 `translate:auto` 的整页 20,000 字符过滤，最多选择 100 个待翻译页面
- 复用 Markdown adapter 和 easy-translate core，将长页面按语义单元分批翻译并保留 checkpoint
- 对超长单个语义单元进行 Unicode 字素安全细分，严格限制每批最多 20 项、4,000 个源字符
- 同步 workflow 与翻译文档说明
- 增加长页面、长正文、空白保真和 Unicode 边界回归测试

## 验证

- `pnpm typecheck`
- `pnpm test`（110/110）
- `pnpm translate:check`
- `git diff --check origin/main..HEAD`
