### PR TITLE
[AI] fix: 阻止空文档更新批次

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -177,6 +177,39 @@ jobs:
         env:
           ALLOW_LARGE_PRUNE: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_large_prune == true }}
         run: |
+          # Remove only unpublished, structurally valid empty releases left by an interrupted older run.
+          node --input-type=module <<'NODE'
+          import { execFileSync } from "node:child_process";
+          import { lstat, readFile, unlink } from "node:fs/promises";
+          const paths = execFileSync("git", [
+            "diff", "--name-only", "-z", "--diff-filter=A", "origin/main...HEAD", "--", "docs/updates",
+          ]).toString().split("\0").filter(Boolean);
+          for (const path of paths) {
+            if (!/^docs\/updates\/[0-9TZ-]+\.json$/u.test(path)) {
+              throw new Error(`Unexpected unpublished release path: ${path}`);
+            }
+            const stat = await lstat(path);
+            if (stat.isSymbolicLink() || !stat.isFile()) {
+              throw new Error(`Unpublished release is not a regular file: ${path}`);
+            }
+            const release = JSON.parse(await readFile(path, "utf8"));
+            const keys = Object.keys(release).sort().join(",");
+            if (keys !== "added,generatedAt,id,modified,removed" ||
+                !Array.isArray(release.added) || !Array.isArray(release.modified) || !Array.isArray(release.removed)) {
+              throw new Error(`Unpublished release has an invalid shape: ${path}`);
+            }
+            const timestamp = new Date(release.generatedAt);
+            const expectedId = Number.isFinite(timestamp.valueOf())
+              ? timestamp.toISOString().replace(/[.:]/gu, "-")
+              : "";
+            if (release.id !== expectedId || path !== `docs/updates/${expectedId}.json`) {
+              throw new Error(`Unpublished release identity does not match its path: ${path}`);
+            }
+            if (release.added.length === 0 && release.modified.length === 0 && release.removed.length === 0) {
+              await unlink(path);
+            }
+          }
+          NODE
           prune_args=(--prune)
           if [[ "$ALLOW_LARGE_PRUNE" == true ]]; then
             prune_args+=(--allow-large-prune)
@@ -186,18 +219,17 @@ jobs:
           # The summary CLI reads commits. A temporary snapshot lets English and its release share one published commit.
           snapshot=$(git commit-tree "$(git write-tree)" -p HEAD -m "[AI] docs: 临时同步快照")
           release_dir=docs/updates
-          if git diff --quiet "origin/main...$snapshot" -- docs/en; then
-            # An empty batch must not overwrite a historical release with the same manifest timestamp.
+          if git diff --quiet "origin/main...$snapshot" -- ':(glob)docs/en/**/*.md'; then
+            # Response-header churn is not an article update and must not publish an empty batch.
             release_dir="$RUNNER_TEMP/empty-batch"
+            git restore --source=origin/main --staged --worktree -- docs/en/.source-manifest.json
           fi
           node scripts/sync-pr-summary.ts \
             --base-ref origin/main --head-ref "$snapshot" \
             --output "$RUNNER_TEMP/sync-summary.md" \
             --release-dir "$release_dir" \
             --release-output "$RUNNER_TEMP/release-path.txt"
-          if [[ "$release_dir" == docs/updates ]]; then
-            git add -- docs/updates
-          fi
+          git add -- docs/updates
           node --input-type=module <<'NODE'
           import { execFileSync } from "node:child_process";
           import { writeFileSync } from "node:fs";

--- a/scripts/tests/workflow-contract.test.ts
+++ b/scripts/tests/workflow-contract.test.ts
@@ -698,17 +698,27 @@ test("continuation conflicts stop before publishing and disallowed code never ge
   }
 });
 
-test("English snapshot produces one release commit and an empty sync does not create a branch", async (t) => {
-  for (const changed of [false, true]) {
+test("English snapshot publishes article changes but not manifest-only churn", async (t) => {
+  for (const change of ["none", "metadata", "article"] as const) {
     const fixture = await localWriterFixture(t);
     await fixture.runStep("Prepare the verified automation branch");
-    if (changed) await writeFile(join(fixture.root, "docs/en/a.md"), "# Updated English\n");
+    if (change === "article") await writeFile(join(fixture.root, "docs/en/a.md"), "# Updated English\n");
+    if (change === "metadata") {
+      const manifestPath = join(fixture.root, "docs/en/.source-manifest.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+      manifest.generatedAt = "2026-09-07T00:00:00.000Z";
+      const [sourceUrl] = Object.keys(manifest.pages);
+      assert.ok(sourceUrl);
+      manifest.pages[sourceUrl].sourceLastModified = "Sun, 06 Sep 2026 18:02:03 GMT";
+      await writeFile(manifestPath, JSON.stringify(manifest));
+    }
     const run = yamlLiteral(await writerStep("Synchronize English and publish the batch release"), /^        run: \|$/);
     fixture.output("bash", ["-e", "-o", "pipefail", "-c", run]);
     const releasePath = (await readFile(join(fixture.runnerTemp, "release-path.txt"), "utf8")).trim();
     const release = JSON.parse(await readFile(releasePath, "utf8"));
+    const changed = change === "article";
     assert.deepEqual(release.modified.map((entry: { path: string }) => entry.path), changed ? ["docs/en/a.md"] : []);
-    assert.equal(fixture.git("rev-list", "--count", "origin/main..HEAD"), changed ? "1" : "0");
+    assert.equal(fixture.git("rev-list", "--count", "origin/main..HEAD"), changed ? "1" : "0", change);
     const tracked = fixture.git("diff", "--name-only", "origin/main...HEAD");
     assert.doesNotMatch(tracked, /translation-result|release-path/);
     if (changed) {
@@ -719,6 +729,32 @@ test("English snapshot produces one release commit and an empty sync does not cr
       assert.equal(fixture.git("ls-remote", "--heads", "origin", `refs/heads/${expectedHeadRef}`), "");
     }
   }
+});
+
+test("a continuation removes an unpublished empty release before publishing translations", async (t) => {
+  const fixture = await localWriterFixture(t);
+  useBotIdentity(fixture);
+  fixture.git("checkout", "-b", expectedHeadRef);
+  const emptyRelease = "docs/updates/2026-09-07T00-00-00-000Z.json";
+  await writeFile(join(fixture.root, emptyRelease), JSON.stringify({
+    id: "2026-09-07T00-00-00-000Z",
+    generatedAt: "2026-09-07T00:00:00.000Z",
+    added: [], modified: [], removed: [],
+  }));
+  await writeFile(join(fixture.root, "docs/zh/a.md"), "# Completed translation\n");
+  fixture.git("add", "--", emptyRelease, "docs/zh/a.md");
+  fixture.git("commit", "-m", "[AI] docs: 更新本轮 OpenAI 中文翻译");
+  const sha = fixture.git("rev-parse", "HEAD");
+  fixture.git("push", "origin", expectedHeadRef);
+  fixture.git("checkout", "main");
+  fixture.git("branch", "-D", expectedHeadRef);
+  const pull = automationPull();
+  pull.head.sha = sha;
+  await fixture.runStep("Prepare the verified automation branch", [pull]);
+  fixture.output("bash", ["-e", "-o", "pipefail", "-c", yamlLiteral(await writerStep("Synchronize English and publish the batch release"), /^        run: \|$/)]);
+  assert.notEqual(fixture.output("git", ["cat-file", "-e", `HEAD:${emptyRelease}`], true).exitCode, 0);
+  assert.notEqual(fixture.output("git", ["cat-file", "-e", `origin/${expectedHeadRef}:${emptyRelease}`], true).exitCode, 0);
+  assert.equal(fixture.git("show", `origin/${expectedHeadRef}:docs/zh/a.md`), "# Completed translation");
 });
 
 test("completed translations are committed with a normal push and a concurrent remote head is preserved", async (t) => {


### PR DESCRIPTION
## 问题

统一工作流把仅有响应头变化的 source manifest 更新误判为英文文章变化，因而发布了 added、modified、removed 全为空的 release。站点门禁随后正确拒绝该空批次，导致自动化 PR #70 无法通过。

## 修复

- 只根据 docs/en 下的 Markdown 文章差异决定是否发布 release
- 仅 manifest 元数据变化时恢复主分支 manifest，并把临时空批次留在 runner 临时目录
- 续跑时只清理尚未进入 main、路径与身份严格匹配且三个变更数组均为空的 release
- 保留非空批次、已完成翻译及现有 PR 身份和防递归校验

## 验证

- pnpm typecheck
- pnpm test：193/193 通过
- pnpm web:typecheck
- pnpm web:lint
- pnpm web:test：20/20 通过
- pnpm web:build
- git diff --check