### PR TITLE
[AI] fix: 容忍 PR head 短暂传播延迟

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -264,17 +264,26 @@ jobs:
             const { readFile } = require("node:fs/promises");
             const { owner, repo } = context.repo;
             const body = `<!-- required_complete=false -->\n\n翻译待完成；本轮保持 draft。\n\n${await readFile(process.env.SYNC_SUMMARY_PATH, "utf8")}`;
-            const assertCurrent = (pull) => {
+            const assertIdentity = (pull) => {
               if (pull.state !== "open" || pull.user.login !== "github-actions[bot]" ||
                   pull.base.ref !== "main" || pull.title !== process.env.PR_TITLE ||
                   pull.head.ref !== process.env.UPDATE_BRANCH || pull.head.repo?.full_name !== `${owner}/${repo}`) {
                 throw new Error("Automation PR identity is no longer trusted and open");
               }
-              if (pull.head.sha !== process.env.PUSHED_HEAD_SHA) throw new Error("Automation PR head changed after publishing");
+            };
+            const fetchCurrent = async (number) => {
+              let current;
+              for (let attempt = 0; attempt < 6; attempt += 1) {
+                ({ data: current } = await github.rest.pulls.get({ owner, repo, pull_number: number }));
+                assertIdentity(current);
+                if (current.head.sha === process.env.PUSHED_HEAD_SHA) return current;
+                if (attempt < 5) await new Promise((resolve) => setTimeout(resolve, 2000));
+              }
+              throw new Error("Automation PR head changed after publishing");
             };
             let pull;
             if (process.env.PR_NUMBER) {
-              ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: Number(process.env.PR_NUMBER) }));
+              pull = { number: Number(process.env.PR_NUMBER) };
             } else {
               const existing = await github.paginate(github.rest.pulls.list, {
                 owner, repo, head: `${owner}:${process.env.UPDATE_BRANCH}`, state: "open", per_page: 100,
@@ -286,14 +295,12 @@ jobs:
                 title: process.env.PR_TITLE, body, draft: true,
               }));
             }
-            ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: pull.number }));
-            assertCurrent(pull);
+            pull = await fetchCurrent(pull.number);
             if (!pull.draft) await github.graphql(`mutation($pullRequestId: ID!) {
               convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) { pullRequest { id } }
             }`, { pullRequestId: pull.node_id });
             await github.rest.pulls.update({ owner, repo, pull_number: pull.number, body });
-            ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: pull.number }));
-            assertCurrent(pull);
+            pull = await fetchCurrent(pull.number);
             if (!pull.draft) throw new Error("Published batch must be draft before translation");
             core.setOutput("number", String(pull.number));
 
@@ -480,18 +487,26 @@ jobs:
             const { owner, repo } = context.repo;
             const complete = process.env.BATCH_COMPLETE === "true";
             const body = await readFile(process.env.PR_BODY_PATH, "utf8");
-            const assertCurrent = (pull) => {
+            const assertIdentity = (pull) => {
               if (pull.state !== "open" || pull.user.login !== "github-actions[bot]" ||
                   pull.base.ref !== "main" || pull.title !== process.env.PR_TITLE ||
                   pull.head.ref !== process.env.UPDATE_BRANCH || pull.head.repo?.full_name !== `${owner}/${repo}`) {
                 throw new Error("Automation PR identity is no longer trusted and open");
               }
-              if (pull.head.sha !== process.env.PUSHED_HEAD_SHA) throw new Error("Automation PR head changed after publishing");
+            };
+            const fetchCurrent = async (number) => {
+              let current;
+              for (let attempt = 0; attempt < 6; attempt += 1) {
+                ({ data: current } = await github.rest.pulls.get({ owner, repo, pull_number: number }));
+                assertIdentity(current);
+                if (current.head.sha === process.env.PUSHED_HEAD_SHA) return current;
+                if (attempt < 5) await new Promise((resolve) => setTimeout(resolve, 2000));
+              }
+              throw new Error("Automation PR head changed after publishing");
             };
             let pull;
             if (process.env.PR_NUMBER) {
-              ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: Number(process.env.PR_NUMBER) }));
-              assertCurrent(pull);
+              pull = await fetchCurrent(Number(process.env.PR_NUMBER));
               await github.rest.pulls.update({ owner, repo, pull_number: pull.number, title: process.env.PR_TITLE, body });
             } else {
               const existing = await github.paginate(github.rest.pulls.list, {
@@ -503,8 +518,7 @@ jobs:
                 title: process.env.PR_TITLE, body, draft: true,
               }));
             }
-            ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: pull.number }));
-            assertCurrent(pull);
+            pull = await fetchCurrent(pull.number);
             if (!complete && !pull.draft) {
               await github.graphql(`mutation($pullRequestId: ID!) {
                 convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) { pullRequest { id } }
@@ -514,8 +528,7 @@ jobs:
                 markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) { pullRequest { id } }
               }`, { pullRequestId: pull.node_id });
             }
-            ({ data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: pull.number }));
-            assertCurrent(pull);
+            pull = await fetchCurrent(pull.number);
             if (pull.draft === complete) throw new Error("Automation PR draft state does not match batch completeness");
             core.setOutput("number", String(pull.number));
             core.notice(`Unified docs PR #${pull.number}`);

--- a/scripts/tests/workflow-contract.test.ts
+++ b/scripts/tests/workflow-contract.test.ts
@@ -460,6 +460,7 @@ async function runWriterApiStep(name: string, options: {
   pull?: WriterPull;
   existing?: boolean;
   staleOnFetch?: number;
+  staleFetches?: number;
   expectedSha?: string;
   createFailure?: boolean;
   events?: Array<{ kind: string; data: Record<string, unknown> }>;
@@ -480,7 +481,9 @@ async function runWriterApiStep(name: string, options: {
           record("get", request);
           fetches++;
           if (options.staleOnFetch === fetches) pull.head.sha = "f".repeat(40);
-          return { data: structuredClone(pull) };
+          const response = structuredClone(pull);
+          if (fetches <= (options.staleFetches ?? 0)) response.head.sha = "f".repeat(40);
+          return { data: response };
         },
         create: async (request: Record<string, unknown>) => {
           record("create", request);
@@ -506,7 +509,7 @@ async function runWriterApiStep(name: string, options: {
   };
   const script = yamlLiteral(await writerStep(name), /^          script: \|$/);
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-  const run = new AsyncFunction("github", "context", "core", "process", "require", script);
+  const run = new AsyncFunction("github", "context", "core", "process", "require", "setTimeout", script);
   await run(github, { repo: { owner: "openai", repo: "docs" } }, {
     setOutput: (key: string, value: unknown) => record("output", { key, value }),
     notice: () => {},
@@ -518,7 +521,7 @@ async function runWriterApiStep(name: string, options: {
   } }, (name: string) => {
     assert.equal(name, "node:fs/promises");
     return { readFile: async () => "required_complete=false\n本轮已翻译" };
-  });
+  }, (callback: () => void) => { callback(); return 0; });
   return events;
 }
 
@@ -549,6 +552,14 @@ test("PR lifecycle rejects closed or foreign identities and refetches the pushed
     await assert.rejects(runWriterApiStep("Create or update the unified pull request", { pull }), /identity|open|trusted/i);
   }
   await assert.rejects(runWriterApiStep("Create or update the unified pull request", { staleOnFetch: 2 }), /head/i);
+});
+
+test("writer tolerates transient PR head propagation but rejects persistent drift", async () => {
+  for (const name of ["Create or recover the draft before translation", "Create or update the unified pull request"]) {
+    const recovered = await runWriterApiStep(name, { staleFetches: 1 });
+    assert.ok(recovered.filter((event) => event.kind === "get").length >= 2, name);
+    await assert.rejects(runWriterApiStep(name, { staleOnFetch: 1 }), /head/i, name);
+  }
 });
 
 test("CI dispatch sends exactly the recorded PR identity and refuses a changed head", async () => {


### PR DESCRIPTION
## 问题

统一工作流推送自动化分支后立即读取 PR。GitHub PR API 偶尔短暂返回旧 head，导致严格 SHA 门禁报 Automation PR head changed after publishing；稍后 PR 和分支实际上会收敛到同一个 SHA。

## 修复

- push 后读取 PR head 时最多重试 6 次、约 10 秒
- 每次读取仍校验 PR 状态、机器人作者、标题、base/head 分支和所属仓库
- 只有 head 与刚推送的 SHA 完全一致才继续
- 持续漂移仍失败关闭，不放宽 CI 派发或自动合并门禁

## 验证

- pnpm typecheck
- pnpm test：194/194 通过
- pnpm web:typecheck
- pnpm web:lint
- pnpm web:test：20/20 通过
- pnpm web:build
- 针对瞬时旧 head 与持续漂移的回归测试通过