### PR TITLE
[AI] ci: 启用文档更新自动合并

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -30,7 +30,7 @@ env:
   BASE_BRANCH: main
   UPDATE_BRANCH: automation/update-openai-docs
   PR_TITLE: "[AI] docs: 同步并翻译 OpenAI 官方文档"
-  AUTO_MERGE_ROLLOUT: canary
+  AUTO_MERGE_ROLLOUT: enabled
 
 jobs:
   update:

--- a/scripts/tests/workflow-contract.test.ts
+++ b/scripts/tests/workflow-contract.test.ts
@@ -369,7 +369,7 @@ async function writerStep(name: string): Promise<string> {
 
 test("writer verifies trusted main and paths before exposing provider secrets", async () => {
   const writer = await readFile(writerPath, "utf8");
-  assert.match(writer, /^  AUTO_MERGE_ROLLOUT: canary$/m);
+  assert.match(writer, /^  AUTO_MERGE_ROLLOUT: enabled$/m);
   assert.match(writer, /^  UPDATE_BRANCH: automation\/update-openai-docs$/m);
   assert.match(writer, /^    if: github.ref == 'refs\/heads\/main'$/m);
   assert.match(writer, /^    environment: translation-production$/m);
@@ -419,7 +419,7 @@ test("writer persists completed pages before validation and reports failures aft
   assert.match(await writerStep("Report failure after preserving the draft pull request"), /exit 1/);
 });
 
-test("CI dispatch and auto merge require complete state and the canary opt-in", async () => {
+test("CI dispatch and auto merge require complete state and an enabled rollout", async () => {
   assert.doesNotMatch(workflow, /createWorkflowDispatch|update-docs\.yml/);
   const dispatch = await writerStep("Dispatch CI for the exact completed head");
   assert.match(dispatch, /if: .*steps.status.outputs.complete == 'true'/);


### PR DESCRIPTION
## 变更

- 将文档更新工作流的自动合并 rollout 从 `canary` 切换为 `enabled`
- 更新工作流契约测试及测试名称
- 仍要求翻译完整、PR 更新成功且 CI 门禁通过后才会自动合并

## 验证

- `node --test --test-name-pattern="writer verifies trusted main|CI dispatch and auto merge" scripts/tests/workflow-contract.test.ts`
- `git diff --check`